### PR TITLE
gathering statistics for calls

### DIFF
--- a/api/src/main/java/io/smallrye/stork/DefaultServiceInstance.java
+++ b/api/src/main/java/io/smallrye/stork/DefaultServiceInstance.java
@@ -1,0 +1,28 @@
+package io.smallrye.stork;
+
+public class DefaultServiceInstance implements ServiceInstance {
+
+    private final long id;
+
+    private final String host;
+
+    private final int port;
+
+    public DefaultServiceInstance(long id, String host, int port) {
+        this.id = id;
+        this.host = host;
+        this.port = port;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+}

--- a/api/src/main/java/io/smallrye/stork/LoadBalancer.java
+++ b/api/src/main/java/io/smallrye/stork/LoadBalancer.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface LoadBalancer {
 
     /**
-     * Provide a single {@link ServiceInstance} from the given list.
+     * Provide a single {@link DefaultServiceInstance} from the given list.
      *
      * @param serviceInstances instances to choose from
      * @return a ServiceInstance

--- a/api/src/main/java/io/smallrye/stork/Service.java
+++ b/api/src/main/java/io/smallrye/stork/Service.java
@@ -1,9 +1,8 @@
 package io.smallrye.stork;
 
-import java.util.List;
-
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+
+import java.util.List;
 
 public class Service {
 
@@ -18,7 +17,7 @@ public class Service {
     }
 
     /**
-     * Provide a single {@link ServiceInstance}
+     * Provide a single {@link DefaultServiceInstance}
      *
      * @return a Uni with a ServiceInstance
      */
@@ -28,7 +27,7 @@ public class Service {
     }
 
     /**
-     * Provide a collection of {@link ServiceInstance}s
+     * Provide a collection of {@link DefaultServiceInstance}s
      *
      * @return a Multi - stream of ServiceInstances
      */

--- a/api/src/main/java/io/smallrye/stork/ServiceInstance.java
+++ b/api/src/main/java/io/smallrye/stork/ServiceInstance.java
@@ -1,28 +1,16 @@
 package io.smallrye.stork;
 
-public final class ServiceInstance {
+public interface ServiceInstance {
+    long getId();
 
-    private final long id;
+    String getHost();
 
-    private final String host;
+    int getPort();
 
-    private final int port;
-
-    public ServiceInstance(long id, String host, int port) {
-        this.id = id;
-        this.host = host;
-        this.port = port;
+    default boolean gatherStatistics() {
+        return false;
     }
 
-    public long getId() {
-        return id;
-    }
-
-    public String getHost() {
-        return host;
-    }
-
-    public int getPort() {
-        return port;
+    default void recordResult(long time, Exception error) {
     }
 }

--- a/api/src/main/java/io/smallrye/stork/ServiceInstanceWithStatGathering.java
+++ b/api/src/main/java/io/smallrye/stork/ServiceInstanceWithStatGathering.java
@@ -1,0 +1,37 @@
+package io.smallrye.stork;
+
+import io.smallrye.stork.spi.CallStatisticsCollector;
+
+public class ServiceInstanceWithStatGathering implements ServiceInstance {
+    private final ServiceInstance delegate;
+    private final CallStatisticsCollector statistics;
+
+    public ServiceInstanceWithStatGathering(ServiceInstance delegate, CallStatisticsCollector statistics) {
+        this.delegate = delegate;
+        this.statistics = statistics;
+    }
+
+    @Override
+    public boolean gatherStatistics() {
+        return true;
+    }
+
+    @Override
+    public long getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public String getHost() {
+        return delegate.getHost();
+    }
+
+    @Override
+    public int getPort() {
+        return delegate.getPort();
+    }
+
+    public void recordResult(long time, Exception error) {
+        statistics.storeResult(getId(), time, error);
+    }
+}

--- a/api/src/main/java/io/smallrye/stork/spi/CallStatisticsCollector.java
+++ b/api/src/main/java/io/smallrye/stork/spi/CallStatisticsCollector.java
@@ -1,0 +1,5 @@
+package io.smallrye.stork.spi;
+
+public interface CallStatisticsCollector {
+    void storeResult(long id, long time, Exception error);
+}

--- a/load-balancer/response-time/pom.xml
+++ b/load-balancer/response-time/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.stork</groupId>
+        <artifactId>smallrye-stork-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>smallrye-stork-load-balancer-response-time</artifactId>
+
+    <name>SmallRye Stork Load Balancer : Response Time</name>
+    <description>SmallRye Stork Load Balancer provider based on response time of the reached endpoints</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>smallrye-stork-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>smallrye-stork-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>smallrye-stork-service-discovery-static-list</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/load-balancer/response-time/src/main/java/io/smallrye/stork/loadbalancer/responsetime/CallStatistics.java
+++ b/load-balancer/response-time/src/main/java/io/smallrye/stork/loadbalancer/responsetime/CallStatistics.java
@@ -1,0 +1,131 @@
+package io.smallrye.stork.loadbalancer.responsetime;
+
+import io.smallrye.stork.spi.CallStatisticsCollector;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CallStatistics implements CallStatisticsCollector {
+
+    private AtomicLong callCount = new AtomicLong(1);
+    private ConcurrentHashMap<Long, CallsData> storage = new ConcurrentHashMap<>();
+
+    static double errorImportanceDeclineFactor = 0.999;
+    static double[] declineFactorPowers = new double[16];
+
+    static double responseTimeFactor = 0.5;
+
+    // declineFactorPowers[i] = declineFactor^2^i
+    // then for n = \sum_{i=0}^{k} 2 ^ f(i) where f(i) \in {0,1},
+    // rescaled error rate is \prod_{i=0}^{k}[f(i) == 1]declineFactorPowers[i]
+
+    static {
+        declineFactorPowers[1] = errorImportanceDeclineFactor;
+        for (int i = 2; i < 16; i++) {
+            declineFactorPowers[i] = declineFactorPowers[i - 1] * declineFactorPowers[i - 1];
+        }
+    }
+
+    @Override
+    public void storeResult(long id, long timeInNs, Exception error) {
+        long callIdx = callCount.incrementAndGet();
+
+        while (true) {
+            CallsData oldData = storage.get(id);
+            if (oldData != null) {
+                CallsData newData;
+                if (error == null) {
+                    double newTotalTime = oldData.weightedTotalTime * responseTimeFactor + timeInNs;
+                    double newWeightSum = oldData.weightSum * responseTimeFactor + 1;
+
+                    newData = new CallsData(callIdx, oldData.lastFailure, newTotalTime, newWeightSum,
+                            oldData.weightedErrorCount);
+                } else {
+                    double rescaledFailureRate = oldData.scaledErrorCount(callIdx - oldData.lastFailure);
+                    newData = new CallsData(oldData.lastSuccess, callIdx, oldData.weightedTotalTime, oldData.weightSum,
+                            rescaledFailureRate + 1);
+                }
+                if (storage.replace(id, oldData, newData)) {
+                    break; // otherwise, try once again, until succeess
+                }
+            } else {
+                // no previously storage data
+                CallsData newData;
+                if (error == null) {
+                    newData = new CallsData(callIdx, 0, timeInNs, 1, 0);
+                } else {
+                    newData = new CallsData(0, callIdx, 0, 0, 1);
+                }
+
+                if (storage.put(callIdx, newData) == null) {
+                    break; // success if there was no data (inserted in the meantime)
+                }
+            }
+        }
+    }
+
+    public CallsData statsForInstance(long id) {
+        return storage.get(id);
+    }
+
+    public long currentCall() {
+        return callCount.get();
+    }
+
+    public CallsData init(long id) {
+        CallsData result = new CallsData(0, 0, 0, 0, 0);
+        storage.put(id, result);
+        return result;
+    }
+
+    public static class CallsData {
+        final long lastFailure;
+        final long lastSuccess;
+        final double weightedTotalTime;
+        final double weightSum;
+        final double weightedErrorCount;
+        final AtomicReference<Boolean> forcedAttemptInProgress = new AtomicReference<>(false);
+
+        private CallsData(long lastSuccess, long lastFailure, double weighedTotalTime, double weightSum,
+                double weighedErrorCount) {
+            this.lastFailure = lastFailure;
+            this.lastSuccess = lastSuccess;
+            this.weightedTotalTime = weighedTotalTime;
+            this.weightSum = weightSum;
+            this.weightedErrorCount = weighedErrorCount;
+        }
+
+        /**
+         * in time, the failures that happened long time (many requests) ago should have decreasing impact.
+         * This function decreases the impact of failures that happened long time ago.
+         *
+         * @param timeSinceLastError amount of requests made, successfully or not, since the last recorded error.
+         *        This contains all requests made with the current load balancer, not only the ones made
+         *        through this service instance
+         * @return new weighed error count
+         */
+        // TODO : test
+        public double scaledErrorCount(long timeSinceLastError) {
+            if (weightedErrorCount == 0) {
+                return 0;
+            }
+
+            // 1 0 1 0 0 0 0 0 is probably better than 0 1 1 1 1 1 1 1 1 1 or even 0 0 1 1 1 1 1 1 1
+            // we need something reasonably decreasing with timeSinceLastError increasing.
+            // let's do sum_{i=0}^{15} [if_failed(now-i)]0.999^i
+            double result = weightedErrorCount;
+            for (int i = 1; i < 16; i++) {
+                if ((timeSinceLastError & i) == 0) {
+                    result *= declineFactorPowers[i];
+                }
+            }
+            return result;
+        }
+
+        public double scaledTime() {
+            return weightedTotalTime / weightSum;
+        }
+
+    }
+}

--- a/load-balancer/response-time/src/main/java/io/smallrye/stork/loadbalancer/responsetime/StatBasedLoadBalancer.java
+++ b/load-balancer/response-time/src/main/java/io/smallrye/stork/loadbalancer/responsetime/StatBasedLoadBalancer.java
@@ -1,0 +1,74 @@
+package io.smallrye.stork.loadbalancer.responsetime;
+
+import io.smallrye.stork.LoadBalancer;
+import io.smallrye.stork.ServiceInstance;
+import io.smallrye.stork.ServiceInstanceWithStatGathering;
+
+import java.util.List;
+
+public class StatBasedLoadBalancer implements LoadBalancer {
+
+    // TODO make them configurable
+    // TODO sampling instead of collecting everything
+    private static final int RETRY_AFTER_FAILURE_THRESHOLD = 10000;
+    private static final long FORCE_RETRY_THRESHOLD = 1000;
+
+    private final CallStatistics callStatistics = new CallStatistics();
+
+    // TODO good tests
+    @Override
+    public ServiceInstance selectServiceInstance(List<ServiceInstance> serviceInstances) {
+        // we may want sampling in the future. Right now let's collect all the results.
+        // compared to IO ops, it should be cheap...
+        ServiceInstance best = null;
+        CallStatistics.CallsData bestData = null;
+        for (ServiceInstance instance : serviceInstances) {
+            CallStatistics.CallsData callsData = callStatistics.statsForInstance(instance.getId());
+            if (callsData == null) {
+                callsData = callStatistics.init(instance.getId()); // to mark that it was used
+                callsData.forcedAttemptInProgress.set(true);
+                best = instance;
+                break;
+            } else if (bestData == null) {
+                bestData = callsData;
+                best = instance;
+            } else {
+                if (timeToRetry(callsData)) {
+                    best = instance;
+                    break;
+                }
+                if (isBetterThan(callsData, bestData)) {
+                    best = instance;
+                    bestData = callsData;
+                }
+            }
+        }
+        return new ServiceInstanceWithStatGathering(best, callStatistics);
+    }
+
+    private boolean isBetterThan(CallStatistics.CallsData callsData, CallStatistics.CallsData bestData) {
+        if (bestData.lastSuccess != 0) {
+            if (callsData.lastSuccess == 0) {
+                return false;
+            }
+            long now = callStatistics.currentCall();
+            // TODO we only take into account the best, we should probably use one of the bests
+            return callsData.scaledTime() * (1 + callsData.scaledErrorCount(now - bestData.lastFailure)) <= bestData
+                    .scaledTime() * (1 + callsData.scaledErrorCount(now - callsData.lastFailure));
+        } else if (callsData.lastSuccess != 0) {
+            return true;
+        } else {
+            return callsData.lastFailure == 0 || callsData.lastFailure < bestData.lastFailure;
+        }
+    }
+
+    private boolean timeToRetry(CallStatistics.CallsData callsData) {
+        if (callsData == null) {
+            return true;
+        }
+        long now = callStatistics.currentCall();
+        return now - callsData.lastFailure > RETRY_AFTER_FAILURE_THRESHOLD
+                && now - callsData.lastSuccess > FORCE_RETRY_THRESHOLD
+                && callsData.forcedAttemptInProgress.compareAndSet(false, true);
+    }
+}

--- a/load-balancer/response-time/src/main/java/io/smallrye/stork/loadbalancer/responsetime/StatBasedLoadBalancerProvider.java
+++ b/load-balancer/response-time/src/main/java/io/smallrye/stork/loadbalancer/responsetime/StatBasedLoadBalancerProvider.java
@@ -1,0 +1,19 @@
+package io.smallrye.stork.loadbalancer.responsetime;
+
+import io.smallrye.stork.LoadBalancer;
+import io.smallrye.stork.ServiceDiscovery;
+import io.smallrye.stork.config.LoadBalancerConfig;
+import io.smallrye.stork.spi.LoadBalancerProvider;
+
+public class StatBasedLoadBalancerProvider implements LoadBalancerProvider {
+
+    @Override
+    public LoadBalancer createLoadBalancer(LoadBalancerConfig config, ServiceDiscovery serviceDiscovery) {
+        return new StatBasedLoadBalancer();
+    }
+
+    @Override
+    public String type() {
+        return "stat-based";
+    }
+}

--- a/load-balancer/response-time/src/main/resources/META-INF/services/io.smallrye.stork.spi.LoadBalancerProvider
+++ b/load-balancer/response-time/src/main/resources/META-INF/services/io.smallrye.stork.spi.LoadBalancerProvider
@@ -1,0 +1,1 @@
+io.smallrye.stork.loadbalancer.responsetime.StatBasedLoadBalancerProvider

--- a/load-balancer/response-time/src/test/java/io/smallrye/stork/loadbalancer/responsetime/StatBasedLoadBalancerTest.java
+++ b/load-balancer/response-time/src/test/java/io/smallrye/stork/loadbalancer/responsetime/StatBasedLoadBalancerTest.java
@@ -1,0 +1,87 @@
+package io.smallrye.stork.loadbalancer.responsetime;
+
+import io.smallrye.stork.Service;
+import io.smallrye.stork.ServiceInstance;
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.StorkTestUtils;
+import io.smallrye.stork.test.TestConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatBasedLoadBalancerTest {
+
+    public static final String FST_SRVC_1 = "http://localhost:8080";
+    public static final String FST_SRVC_2 = "http://localhost:8081";
+    private Stork stork;
+
+    @BeforeEach
+    void setUp() {
+        TestConfigProvider.clear();
+        TestConfigProvider.addServiceConfig("first-service", "stat-based", "static",
+                null,
+                Map.of("1", FST_SRVC_1, "2", FST_SRVC_2));
+
+        stork = StorkTestUtils.getNewStorkInstance();
+    }
+
+    @Test
+    void shouldSelectNotSelectedFirst() {
+        Service service = stork.getService("first-service");
+
+        assertThat(asString(selectInstance(service))).isEqualTo(FST_SRVC_1);
+        assertThat(asString(selectInstance(service))).isEqualTo(FST_SRVC_2);
+    }
+
+    @Test
+    void shouldSelectFastest() {
+        Service service = stork.getService("first-service");
+
+        ServiceInstance svc1 = selectInstance(service);
+        assertThat(asString(svc1)).isEqualTo(FST_SRVC_1);
+        svc1.recordResult(100, null);
+
+        ServiceInstance svc2 = selectInstance(service);
+        assertThat(asString(svc2)).isEqualTo(FST_SRVC_2);
+        svc2.recordResult(10, null);
+
+        ServiceInstance selected;
+
+        selected = selectInstance(service);
+        assertThat(asString(selected)).isEqualTo(FST_SRVC_2);
+
+        svc2.recordResult(10, null);
+        selected = selectInstance(service);
+        assertThat(asString(selected)).isEqualTo(FST_SRVC_2);
+
+        svc2.recordResult(10, null);
+        selected = selectInstance(service);
+        assertThat(asString(selected)).isEqualTo(FST_SRVC_2);
+
+        svc2.recordResult(1000, null);
+        selected = selectInstance(service);
+        assertThat(asString(selected)).isEqualTo(FST_SRVC_1);
+
+        svc1.recordResult(1000, null);
+        selected = selectInstance(service);
+        assertThat(asString(selected)).isEqualTo(FST_SRVC_2);
+
+    }
+
+    private ServiceInstance selectInstance(Service service) {
+        return service.selectServiceInstance().await().atMost(Duration.ofSeconds(5));
+    }
+
+    private String asString(ServiceInstance serviceInstance) {
+        try {
+            return String.format("http://%s:%s", serviceInstance.getHost(), serviceInstance.getPort());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/load-balancer/round-robin/src/main/java/io/smallrye/stork/loadbalancer/roundrobin/RoundRobinLoadBalancer.java
+++ b/load-balancer/round-robin/src/main/java/io/smallrye/stork/loadbalancer/roundrobin/RoundRobinLoadBalancer.java
@@ -1,12 +1,12 @@
 package io.smallrye.stork.loadbalancer.roundrobin;
 
+import io.smallrye.stork.LoadBalancer;
+import io.smallrye.stork.ServiceInstance;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import io.smallrye.stork.LoadBalancer;
-import io.smallrye.stork.ServiceInstance;
 
 public class RoundRobinLoadBalancer implements LoadBalancer {
 
@@ -14,7 +14,7 @@ public class RoundRobinLoadBalancer implements LoadBalancer {
 
     @Override
     public ServiceInstance selectServiceInstance(List<ServiceInstance> serviceInstances) {
-        List<ServiceInstance> modifiableList = new ArrayList<>(serviceInstances.size());
+        List<ServiceInstance> modifiableList = new ArrayList<>(serviceInstances);
         modifiableList.sort(Comparator.comparingLong(ServiceInstance::getId));
         return select(serviceInstances);
     }

--- a/load-balancer/round-robin/src/test/java/io/smallrye/stork/loadbalancer/roundrobin/RoundRobinLoadBalancerTest.java
+++ b/load-balancer/round-robin/src/test/java/io/smallrye/stork/loadbalancer/roundrobin/RoundRobinLoadBalancerTest.java
@@ -1,18 +1,17 @@
 package io.smallrye.stork.loadbalancer.roundrobin;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.Duration;
-import java.util.Map;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import io.smallrye.stork.Service;
 import io.smallrye.stork.ServiceInstance;
 import io.smallrye.stork.Stork;
 import io.smallrye.stork.StorkTestUtils;
 import io.smallrye.stork.test.TestConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RoundRobinLoadBalancerTest {
 
@@ -50,8 +49,7 @@ public class RoundRobinLoadBalancerTest {
     private String selectInstance(Service service) {
         try {
             ServiceInstance serviceInstance = service.selectServiceInstance().await().atMost(Duration.ofSeconds(5));
-            String serviceUrl = String.format("http://%s:%s", serviceInstance.getHost(), serviceInstance.getPort());
-            return serviceUrl;
+            return String.format("http://%s:%s", serviceInstance.getHost(), serviceInstance.getPort());
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
         <module>service-discovery/static-list</module>
         <module>service-discovery/consul</module>
         <module>load-balancer/round-robin</module>
+        <module>load-balancer/response-time</module>
         <module>test-utils</module>
     </modules>
 

--- a/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
+++ b/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
@@ -1,13 +1,7 @@
 package io.smallrye.stork.servicediscovery.consul;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.smallrye.mutiny.Uni;
+import io.smallrye.stork.DefaultServiceInstance;
 import io.smallrye.stork.ServiceDiscovery;
 import io.smallrye.stork.ServiceInstance;
 import io.smallrye.stork.config.ServiceDiscoveryConfig;
@@ -17,6 +11,12 @@ import io.vertx.ext.consul.ConsulClient;
 import io.vertx.ext.consul.ConsulClientOptions;
 import io.vertx.ext.consul.ServiceEntry;
 import io.vertx.ext.consul.ServiceEntryList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class ConsulServiceDiscovery implements ServiceDiscovery {
 
@@ -69,7 +69,7 @@ public class ConsulServiceDiscovery implements ServiceDiscovery {
         List<ServiceInstance> serviceInstances = new ArrayList<>();
         for (ServiceEntry serviceEntry : list) {
             // TODO: reuse service instance IDs on refresh (so that they don't change)
-            ServiceInstance serviceInstance = new ServiceInstance(ServiceInstanceIds.next(),
+            ServiceInstance serviceInstance = new DefaultServiceInstance(ServiceInstanceIds.next(),
                     serviceEntry.getService().getAddress(), serviceEntry.getService().getPort());
             serviceInstances.add(serviceInstance);
         }

--- a/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscovery.java
+++ b/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscovery.java
@@ -1,17 +1,18 @@
 package io.smallrye.stork.servicediscovery.staticlist;
 
-import java.util.Collections;
-import java.util.List;
-
 import io.smallrye.mutiny.Uni;
+import io.smallrye.stork.DefaultServiceInstance;
 import io.smallrye.stork.ServiceDiscovery;
 import io.smallrye.stork.ServiceInstance;
+
+import java.util.Collections;
+import java.util.List;
 
 public final class StaticListServiceDiscovery implements ServiceDiscovery {
 
     private final List<ServiceInstance> instances;
 
-    public StaticListServiceDiscovery(List<ServiceInstance> instances) {
+    public StaticListServiceDiscovery(List<DefaultServiceInstance> instances) {
         this.instances = Collections.unmodifiableList(instances);
     }
 

--- a/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProvider.java
+++ b/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProvider.java
@@ -1,5 +1,11 @@
 package io.smallrye.stork.servicediscovery.staticlist;
 
+import io.smallrye.stork.DefaultServiceInstance;
+import io.smallrye.stork.ServiceDiscovery;
+import io.smallrye.stork.config.ServiceDiscoveryConfig;
+import io.smallrye.stork.spi.ServiceDiscoveryProvider;
+import io.smallrye.stork.spi.ServiceInstanceIds;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -7,12 +13,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import io.smallrye.stork.ServiceDiscovery;
-import io.smallrye.stork.ServiceInstance;
-import io.smallrye.stork.config.ServiceDiscoveryConfig;
-import io.smallrye.stork.spi.ServiceDiscoveryProvider;
-import io.smallrye.stork.spi.ServiceInstanceIds;
 
 public class StaticListServiceDiscoveryProvider implements ServiceDiscoveryProvider {
 
@@ -26,7 +26,7 @@ public class StaticListServiceDiscoveryProvider implements ServiceDiscoveryProvi
         // stork.<service-name>.discovery.3=...
         Map<String, String> parameters = config.parameters();
         Pattern number = Pattern.compile("\\d+");
-        List<ServiceInstance> addressList = new ArrayList<>();
+        List<DefaultServiceInstance> addressList = new ArrayList<>();
 
         parameters.keySet().stream()
                 .filter(k -> number.matcher(k).matches())
@@ -37,7 +37,7 @@ public class StaticListServiceDiscoveryProvider implements ServiceDiscoveryProvi
                         url = new URL(parameters.get(k));
                         String host = url.getHost();
                         int port = url.getPort();
-                        addressList.add(new ServiceInstance(ServiceInstanceIds.next(), host, port));
+                        addressList.add(new DefaultServiceInstance(ServiceInstanceIds.next(), host, port));
                     } catch (MalformedURLException e) {
                         throw new IllegalArgumentException(
                                 "Address not parseable to URL: " + url + " for service " + serviceName);


### PR DESCRIPTION
This change adds an API to gather statistics of calls and a (not well tested, probably not optimal) statistics based load balancer.
The purpose of the load balancer is to validate the API of gathering the information, not to provide a production-ready solution
