### PR TITLE
refactor: make load balancer optional.

### DIFF
--- a/api/src/main/java/io/smallrye/stork/Stork.java
+++ b/api/src/main/java/io/smallrye/stork/Stork.java
@@ -99,7 +99,8 @@ public final class Stork {
                 loadBalancer = loadBalancerProvider.createLoadBalancer(loadBalancerConfig, serviceDiscovery);
             }
 
-            services.put(serviceConfig.serviceName(), new Service(serviceConfig.serviceName(), loadBalancer, serviceDiscovery));
+            services.put(serviceConfig.serviceName(),
+                    new Service(serviceConfig.serviceName(), Optional.ofNullable(loadBalancer), serviceDiscovery));
         }
     }
 


### PR DESCRIPTION
Fixes #92

I think it makes sense to define the load balancer as `Optional` since it is possible to have a use case without it. 