### PR TITLE
Add metadata and labels to ServiceInstance for helping the load balancer

### DIFF
--- a/api/src/main/java/io/smallrye/stork/DefaultServiceInstance.java
+++ b/api/src/main/java/io/smallrye/stork/DefaultServiceInstance.java
@@ -19,7 +19,7 @@ public class DefaultServiceInstance implements ServiceInstance {
 
     public DefaultServiceInstance(long id, String host, int port, boolean secure) {
         this(id, host, port, secure, Collections.emptyMap(),
-                new Metadata<MetadataKey>(Collections.emptyMap()));
+                new Metadata());
     }
 
     public DefaultServiceInstance(long id, String host, int port, boolean secure, Map<String, String> labels,

--- a/api/src/main/java/io/smallrye/stork/DefaultServiceInstance.java
+++ b/api/src/main/java/io/smallrye/stork/DefaultServiceInstance.java
@@ -19,7 +19,7 @@ public class DefaultServiceInstance implements ServiceInstance {
 
     public DefaultServiceInstance(long id, String host, int port, boolean secure) {
         this(id, host, port, secure, Collections.emptyMap(),
-                new Metadata());
+                Metadata.empty());
     }
 
     public DefaultServiceInstance(long id, String host, int port, boolean secure, Map<String, String> labels,

--- a/api/src/main/java/io/smallrye/stork/DefaultServiceInstance.java
+++ b/api/src/main/java/io/smallrye/stork/DefaultServiceInstance.java
@@ -15,20 +15,21 @@ public class DefaultServiceInstance implements ServiceInstance {
 
     private final Map<String, String> labels;
 
-    private final Map<String, Object> metadata;
+    private Metadata<? extends MetadataKey> metadata;
 
     public DefaultServiceInstance(long id, String host, int port, boolean secure) {
-        this(id, host, port, secure, Collections.emptyMap(), Collections.emptyMap());
+        this(id, host, port, secure, Collections.emptyMap(),
+                new Metadata<MetadataKey>(Collections.emptyMap()));
     }
 
     public DefaultServiceInstance(long id, String host, int port, boolean secure, Map<String, String> labels,
-            Map<String, Object> metadata) {
+            Metadata<? extends MetadataKey> metadata) {
         this.id = id;
         this.host = host;
         this.port = port;
         this.secure = secure;
         this.labels = Collections.unmodifiableMap(labels);
-        this.metadata = Collections.unmodifiableMap(metadata);
+        this.metadata = metadata;
     }
 
     @Override
@@ -52,7 +53,7 @@ public class DefaultServiceInstance implements ServiceInstance {
     }
 
     @Override
-    public Map<String, Object> getMetadata() {
+    public Metadata<? extends MetadataKey> getMetadata() {
         return metadata;
     }
 

--- a/api/src/main/java/io/smallrye/stork/Metadata.java
+++ b/api/src/main/java/io/smallrye/stork/Metadata.java
@@ -1,41 +1,108 @@
 package io.smallrye.stork;
 
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
+/**
+ * Service Instance metadata.
+ * <p>
+ * This class stores service instance metadata that can be used by the load balancer to select the service instance to use.
+ * <p>
+ * Instances of this class are <strong>immutable</strong>. Modification operations return new instances.
+ * <p>
+ * You can creates new instances using the {@link #of(Class)}, {@link #of(Class, Map)} and {@link #with(Enum, Object)}methods.
+ * <p>
+ */
 public class Metadata<T extends Enum<T>> {
 
-    private EnumMap<T, Object> metatada;
-    Class<T> enumType;
+    private final EnumMap<T, Object> metatada;
+    private final Class<T> clazz;
+    private static final Metadata EMPTY = new Metadata(DefaultMetadataKey.class, Collections.emptyMap());
 
-    public Metadata(Class<T> key) {
-        this.metatada = new EnumMap<T, Object>(key);
-        this.enumType = key;
+    private Metadata(Class<T> key, Map<T, Object> metatada) {
+        if (metatada.isEmpty()) {
+            this.metatada = new EnumMap<T, Object>(key);
+            this.clazz = key;
+        } else {
+            this.metatada = new EnumMap<T, Object>(metatada);
+            this.clazz = key;
+        }
     }
 
-    public Metadata() {
-
+    /**
+     * Returns an empty set of metadata.
+     *
+     * @return the empty instance
+     */
+    public static Metadata empty() {
+        return EMPTY;
     }
 
-    public Map<T, Object> getMetadata() {
+    /**
+     * Returns an instance of {@link Metadata} containing metadata values.
+     *
+     * @param metadata the metadata, must not be {@code null}, must not contain {@code null},
+     *        must not contain multiple objects of the same class
+     * @return the new metadata
+     */
+    public static Metadata of(Class<?> key, Map<?, Object> metadata) {
+        if (metadata == null) {
+            throw new IllegalArgumentException("`metadata` must not be `null`");
+        }
+        return new Metadata(key, metadata);
+    }
+
+    /**
+     * Returns an instance of {@link Metadata} containing an empty set of values.
+     *
+     * @param key the type of metadata, must not be {@code null}
+     * @return the new metadata
+     */
+    public static Metadata of(Class<?> key) {
+        if (key == null) {
+            throw new IllegalArgumentException("`key` must not be `null`");
+        }
+        return new Metadata(key, Collections.emptyMap());
+    }
+
+    /**
+     * Creates a new instance of {@link Metadata} with the current entries, plus {@code item}.
+     * If the current set of metadata contains already an instance of the class of {@code item}, the value is replaced
+     * in the returned {@link Metadata}.
+     *
+     * @param item the metadata to be added, must not be {@code null}.
+     * @return the new instance of {@link Metadata}
+     */
+    public Metadata with(T key, Object item) {
+        if (key == null) {
+            throw new IllegalArgumentException("`key` must not be `null`");
+        }
+        if (item == null) {
+            throw new IllegalArgumentException(key.name() + " should not be `null`");
+        }
+        EnumMap<T, Object> copy = new EnumMap<>(metatada);
+        copy.put(key, item);
+        return new Metadata(this.clazz, copy);
+    }
+
+    public EnumMap<T, Object> getMetadata() {
         return metatada;
     }
 
-    public Optional<Object> get(T key) {
-        if (key == null) {
-            throw new IllegalArgumentException("key must not be `null`");
+    public enum DefaultMetadataKey implements MetadataKey {
+        GENERIC_METADATA_KEY("generic");
+
+        private String name;
+
+        DefaultMetadataKey(String name) {
+            this.name = name;
         }
-        return Optional.ofNullable(metatada.get(key));
-    }
 
-    public void put(T key, Object o) {
-        metatada.put(key, o);
-    }
-
-    public Set<T> keySet() {
-        return Set.of(enumType.getEnumConstants());
+        @Override
+        public String getName() {
+            return name;
+        }
     }
 
 }

--- a/api/src/main/java/io/smallrye/stork/Metadata.java
+++ b/api/src/main/java/io/smallrye/stork/Metadata.java
@@ -1,0 +1,19 @@
+package io.smallrye.stork;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class Metadata<T extends MetadataKey> {
+
+    private Map<T, Object> metatada;
+
+    public Metadata(Map<T, Object> metatada) {
+        this.metatada = Collections.unmodifiableMap(metatada);
+
+    }
+
+    public Map<T, Object> getMetadata() {
+        return metatada;
+    }
+
+}

--- a/api/src/main/java/io/smallrye/stork/Metadata.java
+++ b/api/src/main/java/io/smallrye/stork/Metadata.java
@@ -1,19 +1,41 @@
 package io.smallrye.stork;
 
-import java.util.Collections;
+import java.util.EnumMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
-public class Metadata<T extends MetadataKey> {
+public class Metadata<T extends Enum<T>> {
 
-    private Map<T, Object> metatada;
+    private EnumMap<T, Object> metatada;
+    Class<T> enumType;
 
-    public Metadata(Map<T, Object> metatada) {
-        this.metatada = Collections.unmodifiableMap(metatada);
+    public Metadata(Class<T> key) {
+        this.metatada = new EnumMap<T, Object>(key);
+        this.enumType = key;
+    }
+
+    public Metadata() {
 
     }
 
     public Map<T, Object> getMetadata() {
         return metatada;
+    }
+
+    public Optional<Object> get(T key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key must not be `null`");
+        }
+        return Optional.ofNullable(metatada.get(key));
+    }
+
+    public void put(T key, Object o) {
+        metatada.put(key, o);
+    }
+
+    public Set<T> keySet() {
+        return Set.of(enumType.getEnumConstants());
     }
 
 }

--- a/api/src/main/java/io/smallrye/stork/MetadataKey.java
+++ b/api/src/main/java/io/smallrye/stork/MetadataKey.java
@@ -1,0 +1,5 @@
+package io.smallrye.stork;
+
+public interface MetadataKey {
+    String getName();
+}

--- a/api/src/main/java/io/smallrye/stork/ServiceInstance.java
+++ b/api/src/main/java/io/smallrye/stork/ServiceInstance.java
@@ -31,8 +31,8 @@ public interface ServiceInstance {
     /**
      * @return the metadata of the instance, empty if none.
      */
-    default Map<String, Object> getMetadata() {
-        return Collections.emptyMap();
+    default Metadata<? extends MetadataKey> getMetadata() {
+        return new Metadata<MetadataKey>(Collections.emptyMap());
     }
 
     /**

--- a/api/src/main/java/io/smallrye/stork/ServiceInstance.java
+++ b/api/src/main/java/io/smallrye/stork/ServiceInstance.java
@@ -32,7 +32,7 @@ public interface ServiceInstance {
      * @return the metadata of the instance, empty if none.
      */
     default Metadata<? extends MetadataKey> getMetadata() {
-        return new Metadata<MetadataKey>(Collections.emptyMap());
+        return new Metadata();
     }
 
     /**

--- a/api/src/main/java/io/smallrye/stork/ServiceInstance.java
+++ b/api/src/main/java/io/smallrye/stork/ServiceInstance.java
@@ -32,7 +32,7 @@ public interface ServiceInstance {
      * @return the metadata of the instance, empty if none.
      */
     default Metadata<? extends MetadataKey> getMetadata() {
-        return new Metadata();
+        return Metadata.empty();
     }
 
     /**

--- a/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulMetadataKey.java
+++ b/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulMetadataKey.java
@@ -1,0 +1,22 @@
+package io.smallrye.stork.servicediscovery.consul;
+
+import io.smallrye.stork.MetadataKey;
+
+public enum ConsulMetadataKey implements MetadataKey {
+
+    META_CONSUL_SERVICE_ID("consul-service-id"),
+    META_CONSUL_SERVICE_NODE("consul-service-node"),
+    META_CONSUL_SERVICE_NODE_ADDRESS("consul-service-node-address");
+
+    private String name;
+
+    ConsulMetadataKey(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+}

--- a/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
+++ b/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
@@ -89,10 +89,7 @@ public class ConsulServiceDiscovery extends CachingServiceDiscovery {
         for (ServiceEntry serviceEntry : list) {
             Service service = serviceEntry.getService();
             Map<String, String> labels = service.getTags().stream().collect(Collectors.toMap(Function.identity(), s -> s));
-            Metadata<ConsulMetadataKey> consulMetadata = new Metadata<>(ConsulMetadataKey.class);
-            consulMetadata.put(META_CONSUL_SERVICE_ID, service.getId());
-            consulMetadata.put(META_CONSUL_SERVICE_NODE, service.getNode());
-            consulMetadata.put(META_CONSUL_SERVICE_NODE_ADDRESS, service.getNodeAddress());
+            Metadata<ConsulMetadataKey> consulMetadata = createConsulMetadata(serviceEntry);
             String address = service.getAddress();
             int port = serviceEntry.getService().getPort();
             if (address == null) {
@@ -109,5 +106,19 @@ public class ConsulServiceDiscovery extends CachingServiceDiscovery {
             }
         }
         return serviceInstances;
+    }
+
+    private Metadata<ConsulMetadataKey> createConsulMetadata(ServiceEntry service) {
+        Metadata<ConsulMetadataKey> consulMetadata = Metadata.of(ConsulMetadataKey.class);
+        if (service.getService() != null && service.getService().getId() != null) {
+            consulMetadata = consulMetadata.with(META_CONSUL_SERVICE_ID, service.getService().getId());
+        }
+        if (service.getNode() != null && service.getNode().getName() != null) {
+            consulMetadata = consulMetadata.with(META_CONSUL_SERVICE_NODE, service.getNode().getName());
+        }
+        if (service.getNode() != null && service.getNode().getAddress() != null) {
+            consulMetadata = consulMetadata.with(META_CONSUL_SERVICE_NODE_ADDRESS, service.getNode().getAddress());
+        }
+        return consulMetadata;
     }
 }

--- a/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
+++ b/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
@@ -4,13 +4,11 @@ import static io.smallrye.stork.config.StorkConfigHelper.get;
 import static io.smallrye.stork.config.StorkConfigHelper.getBoolean;
 import static io.smallrye.stork.config.StorkConfigHelper.getInteger;
 import static io.smallrye.stork.config.StorkConfigHelper.getOrDefault;
-
-import static io.smallrye.stork.servicediscovery.consul.ConsulMetadataKey.*;
 import static io.smallrye.stork.servicediscovery.consul.ConsulMetadataKey.META_CONSUL_SERVICE_ID;
 import static io.smallrye.stork.servicediscovery.consul.ConsulMetadataKey.META_CONSUL_SERVICE_NODE;
+import static io.smallrye.stork.servicediscovery.consul.ConsulMetadataKey.META_CONSUL_SERVICE_NODE_ADDRESS;
 
 import java.util.ArrayList;
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -90,12 +88,11 @@ public class ConsulServiceDiscovery extends CachingServiceDiscovery {
 
         for (ServiceEntry serviceEntry : list) {
             Service service = serviceEntry.getService();
-            Map<ConsulMetadataKey, Object> metadata = new EnumMap<>(ConsulMetadataKey.class);
             Map<String, String> labels = service.getTags().stream().collect(Collectors.toMap(Function.identity(), s -> s));
-            metadata.put(META_CONSUL_SERVICE_ID, service.getId());
-            metadata.put(META_CONSUL_SERVICE_NODE, service.getNode());
-            metadata.put(META_CONSUL_SERVICE_NODE_ADDRESS, service.getNodeAddress());
-            Metadata<ConsulMetadataKey> consulMetadata = new Metadata<>(metadata);
+            Metadata<ConsulMetadataKey> consulMetadata = new Metadata<>(ConsulMetadataKey.class);
+            consulMetadata.put(META_CONSUL_SERVICE_ID, service.getId());
+            consulMetadata.put(META_CONSUL_SERVICE_NODE, service.getNode());
+            consulMetadata.put(META_CONSUL_SERVICE_NODE_ADDRESS, service.getNodeAddress());
             String address = service.getAddress();
             int port = serviceEntry.getService().getPort();
             if (address == null) {

--- a/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryIT.java
+++ b/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryIT.java
@@ -1,12 +1,14 @@
 package io.smallrye.stork.servicediscovery.consul;
 
-import static io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscovery.META_CONSUL_SERVICE_ID;
-import static io.smallrye.stork.servicediscovery.consul.ConsulMetadataKey.*;
+import static io.smallrye.stork.servicediscovery.consul.ConsulMetadataKey.META_CONSUL_SERVICE_ID;
+import static io.smallrye.stork.servicediscovery.consul.ConsulMetadataKey.META_CONSUL_SERVICE_NODE;
+import static io.smallrye.stork.servicediscovery.consul.ConsulMetadataKey.META_CONSUL_SERVICE_NODE_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -159,8 +161,8 @@ public class ConsulServiceDiscoveryIT {
                         "application", "my-consul-service"));
         stork = StorkTestUtils.getNewStorkInstance();
         //Given a service `my-service` registered in consul
-        setUpServices("my-consul-service", 8406, "consul.com");
-        setUpServices("another-service", 8606, "another.example.com");
+        registerService("my-consul-service", 8406, null, "consul.com");
+        registerService("another-service", 8606, null, "another.example.com");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -262,7 +264,7 @@ public class ConsulServiceDiscoveryIT {
     private void deregisterServiceInstances(List<ServiceInstance> serviceInstances) throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         List<String> consulIds = serviceInstances.stream().map(ServiceInstance::getMetadata)
-                .map(metadata -> metadata.get(META_CONSUL_SERVICE_ID))
+                .map(metadata -> metadata.getMetadata().get(META_CONSUL_SERVICE_ID))
                 .filter(consulId -> consulId instanceof String)
                 .map(consulId -> (String) consulId)
                 .collect(Collectors.toList());

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesMetadataKey.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesMetadataKey.java
@@ -14,6 +14,6 @@ public enum KubernetesMetadataKey implements MetadataKey {
 
     @Override
     public String getName() {
-        return null;
+        return name;
     }
 }

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesMetadataKey.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesMetadataKey.java
@@ -1,0 +1,19 @@
+package io.smallrye.stork.servicediscovery.kubernetes;
+
+import io.smallrye.stork.MetadataKey;
+
+public enum KubernetesMetadataKey implements MetadataKey {
+
+    META_K8S_SERVICE_ID("k8s-service-id");
+
+    private String name;
+
+    KubernetesMetadataKey(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
@@ -1,10 +1,10 @@
 package io.smallrye.stork.servicediscovery.kubernetes;
 
 import static io.smallrye.stork.config.StorkConfigHelper.getOrDefault;
+import static io.smallrye.stork.servicediscovery.kubernetes.KubernetesMetadataKey.META_K8S_SERVICE_ID;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -120,10 +120,8 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
                                 ? endPoints.getMetadata().getLabels()
                                 : Collections.emptyMap();
                         //TODO add some useful metadata?
-                        Map<KubernetesMetadataKey, Object> metadata = new EnumMap<>(KubernetesMetadataKey.class);
-                        metadata.put(META_K8S_SERVICE_ID, hostname);
-                        Metadata<KubernetesMetadataKey> k8sMetadata = new Metadata<>(metadata);
-
+                        Metadata<KubernetesMetadataKey> k8sMetadata = new Metadata<>(KubernetesMetadataKey.class);
+                        k8sMetadata.put(META_K8S_SERVICE_ID, hostname);
                         serviceInstances.add(new DefaultServiceInstance(ServiceInstanceIds.next(), hostname, port, secure,
                                 labels, k8sMetadata));
                     }

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
@@ -120,10 +120,9 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
                                 ? endPoints.getMetadata().getLabels()
                                 : Collections.emptyMap();
                         //TODO add some useful metadata?
-                        Metadata<KubernetesMetadataKey> k8sMetadata = new Metadata<>(KubernetesMetadataKey.class);
-                        k8sMetadata.put(META_K8S_SERVICE_ID, hostname);
+                        Metadata<KubernetesMetadataKey> k8sMetadata = Metadata.of(KubernetesMetadataKey.class);
                         serviceInstances.add(new DefaultServiceInstance(ServiceInstanceIds.next(), hostname, port, secure,
-                                labels, k8sMetadata));
+                                labels, k8sMetadata.with(META_K8S_SERVICE_ID, hostname)));
                     }
                 }
             }

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
@@ -4,6 +4,7 @@ import static io.smallrye.stork.config.StorkConfigHelper.getOrDefault;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -21,6 +22,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.stork.CachingServiceDiscovery;
 import io.smallrye.stork.DefaultServiceInstance;
+import io.smallrye.stork.Metadata;
 import io.smallrye.stork.ServiceInstance;
 import io.smallrye.stork.config.ServiceDiscoveryConfig;
 import io.smallrye.stork.spi.ServiceInstanceIds;
@@ -118,9 +120,12 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
                                 ? endPoints.getMetadata().getLabels()
                                 : Collections.emptyMap();
                         //TODO add some useful metadata?
-                        Map<String, Object> metadata = Collections.emptyMap();
+                        Map<KubernetesMetadataKey, Object> metadata = new EnumMap<>(KubernetesMetadataKey.class);
+                        metadata.put(META_K8S_SERVICE_ID, hostname);
+                        Metadata<KubernetesMetadataKey> k8sMetadata = new Metadata<>(metadata);
+
                         serviceInstances.add(new DefaultServiceInstance(ServiceInstanceIds.next(), hostname, port, secure,
-                                labels, metadata));
+                                labels, k8sMetadata));
                     }
                 }
             }

--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
@@ -1,5 +1,7 @@
 package io.smallrye.stork.servicediscovery.kubernetes;
 
+import static io.smallrye.stork.servicediscovery.kubernetes.KubernetesMetadataKey.META_K8S_SERVICE_ID;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
@@ -20,6 +22,7 @@ import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.smallrye.stork.Metadata;
 import io.smallrye.stork.Service;
 import io.smallrye.stork.ServiceInstance;
 import io.smallrye.stork.Stork;
@@ -51,7 +54,7 @@ public class KubernetesServiceDiscoveryTest {
 
         String serviceName = "svc";
 
-        setUpKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
+        registerKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -67,6 +70,14 @@ public class KubernetesServiceDiscoveryTest {
         assertThat(instances.get().stream().map(ServiceInstance::getPort)).allMatch(p -> p == 8080);
         assertThat(instances.get().stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("10.96.96.231",
                 "10.96.96.232", "10.96.96.233");
+        instances.get().stream().map(ServiceInstance::getLabels)
+                .forEach(serviceInstanceLabels -> assertThat(serviceInstanceLabels)
+                        .contains(entry("app.kubernetes.io/name", "svc"), entry("app.kubernetes.io/version", "1.0")));
+        instances.get().stream().map(ServiceInstance::getMetadata).forEach(metadata -> {
+            Metadata<KubernetesMetadataKey> k8sMetadata = (Metadata<KubernetesMetadataKey>) metadata;
+            assertThat(k8sMetadata.getMetadata()).containsKey(META_K8S_SERVICE_ID);
+        });
+
     }
 
     @Test
@@ -106,7 +117,7 @@ public class KubernetesServiceDiscoveryTest {
 
         String serviceName = "svc";
 
-        setUpKubernetesService(serviceName, "ns1", "10.96.96.231", "10.96.96.232", "10.96.96.233");
+        registerKubernetesService(serviceName, "ns1", "10.96.96.231", "10.96.96.232", "10.96.96.233");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -122,6 +133,13 @@ public class KubernetesServiceDiscoveryTest {
         assertThat(instances.get().stream().map(ServiceInstance::getPort)).allMatch(p -> p == 8080);
         assertThat(instances.get().stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("10.96.96.231",
                 "10.96.96.232", "10.96.96.233");
+        instances.get().stream().map(ServiceInstance::getLabels)
+                .forEach(serviceInstanceLabels -> assertThat(serviceInstanceLabels)
+                        .contains(entry("app.kubernetes.io/name", "svc"), entry("app.kubernetes.io/version", "1.0")));
+        instances.get().stream().map(ServiceInstance::getMetadata).forEach(metadata -> {
+            Metadata<KubernetesMetadataKey> k8sMetadata = (Metadata<KubernetesMetadataKey>) metadata;
+            assertThat(k8sMetadata.getMetadata()).containsKey(META_K8S_SERVICE_ID);
+        });
     }
 
     @Test
@@ -132,8 +150,8 @@ public class KubernetesServiceDiscoveryTest {
         Stork stork = StorkTestUtils.getNewStorkInstance();
         String serviceName = "svc";
 
-        setUpKubernetesService(serviceName, "ns1", "10.96.96.231", "10.96.96.232", "10.96.96.233");
-        setUpKubernetesService(serviceName, "ns2", "10.99.99.241", "10.99.99.242", "10.99.99.243");
+        registerKubernetesService(serviceName, "ns1", "10.96.96.231", "10.96.96.232", "10.96.96.233");
+        registerKubernetesService(serviceName, "ns2", "10.99.99.241", "10.99.99.242", "10.99.99.243");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -149,6 +167,13 @@ public class KubernetesServiceDiscoveryTest {
         assertThat(instances.get().stream().map(ServiceInstance::getPort)).allMatch(p -> p == 8080);
         assertThat(instances.get().stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("10.96.96.231",
                 "10.96.96.232", "10.96.96.233", "10.99.99.241", "10.99.99.242", "10.99.99.243");
+        instances.get().stream().map(ServiceInstance::getLabels)
+                .forEach(serviceInstanceLabels -> assertThat(serviceInstanceLabels)
+                        .contains(entry("app.kubernetes.io/name", "svc"), entry("app.kubernetes.io/version", "1.0")));
+        instances.get().stream().map(ServiceInstance::getMetadata).forEach(metadata -> {
+            Metadata<KubernetesMetadataKey> k8sMetadata = (Metadata<KubernetesMetadataKey>) metadata;
+            assertThat(k8sMetadata.getMetadata()).containsKey(META_K8S_SERVICE_ID);
+        });
     }
 
     @Test
@@ -164,7 +189,7 @@ public class KubernetesServiceDiscoveryTest {
 
         String serviceName = "svc";
 
-        setUpKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
+        registerKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -206,7 +231,7 @@ public class KubernetesServiceDiscoveryTest {
 
         String serviceName = "svc";
 
-        setUpKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
+        registerKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -244,7 +269,7 @@ public class KubernetesServiceDiscoveryTest {
 
         String serviceName = "svc";
 
-        setUpKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
+        registerKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -264,7 +289,7 @@ public class KubernetesServiceDiscoveryTest {
         Map<String, Long> idsByHostname = mapHostnameToIds(instances.get());
 
         client.endpoints().withName(serviceName).delete();
-        setUpKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232");
+        registerKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232");
 
         Thread.sleep(5000);
 
@@ -280,7 +305,7 @@ public class KubernetesServiceDiscoveryTest {
         }
 
         client.endpoints().withName(serviceName).delete();
-        setUpKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.234");
+        registerKubernetesService(serviceName, null, "10.96.96.231", "10.96.96.232", "10.96.96.234");
 
         Thread.sleep(5000);
 
@@ -308,11 +333,15 @@ public class KubernetesServiceDiscoveryTest {
         return result;
     }
 
-    private void setUpKubernetesService(String serviceName, String namespace, String... ipAdresses) {
+    private void registerKubernetesService(String serviceName, String namespace, String... ipAdresses) {
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put("app.kubernetes.io/name", "svc");
+        labels.put("app.kubernetes.io/version", "1.0");
         List<EndpointAddress> endpointAddresses = Arrays.stream(ipAdresses)
                 .map(ipAdress -> new EndpointAddressBuilder().withIp(ipAdress).build()).collect(Collectors.toList());
         Endpoints endpoint = new EndpointsBuilder()
-                .withNewMetadata().withName(serviceName).endMetadata()
+                .withNewMetadata().withName(serviceName).withLabels(labels).endMetadata()
                 .addToSubsets(new EndpointSubsetBuilder().withAddresses(endpointAddresses)
                         .addToPorts(new EndpointPortBuilder().withPort(8080).build())
                         .build())

--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
@@ -89,8 +89,8 @@ public class KubernetesServiceDiscoveryTest {
 
         String serviceName = "svc";
 
-        setUpKubernetesService("rest-service", null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
-        setUpKubernetesService("svc", null, "10.95.95.125");
+        registerKubernetesService("rest-service", null, "10.96.96.231", "10.96.96.232", "10.96.96.233");
+        registerKubernetesService("svc", null, "10.95.95.125");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 


### PR DESCRIPTION
As disused together I added two structures to the `ServiceInstance` for storing labels and other stuff which could be useful for selecting the instance to use. Finally I added a extra layer `Metadata` wrapping the `Map<String, Object>` because it adds a meaningfull value I think.
This is a Draft because the `Metadata` object can still be improved and overall it needs to be documented also but want to have already your thoughts.