### PR TITLE
avoid NPE during tests

### DIFF
--- a/microprofile/src/main/java/io/smallrye/stork/microprofile/MicroProfileConfigProvider.java
+++ b/microprofile/src/main/java/io/smallrye/stork/microprofile/MicroProfileConfigProvider.java
@@ -78,18 +78,18 @@ public class MicroProfileConfigProvider implements ConfigProvider {
             String loadBalancerType = properties.get(LOAD_BALANCER);
             builder.setServiceName(serviceName);
             if (loadBalancerType != null) {
-                SimpleServiceConfig.SimpleLoadBalancerConfig loadBalancer = new SimpleServiceConfig.SimpleLoadBalancerConfig(
+                SimpleServiceConfig.SimpleLoadBalancerConfig loadBalancerConfig = new SimpleServiceConfig.SimpleLoadBalancerConfig(
                         loadBalancerType, propertiesForPrefix(LOAD_BALANCER, properties));
 
-                builder = builder.setLoadBalancer(loadBalancer);
+                builder = builder.setLoadBalancer(loadBalancerConfig);
             }
 
             String serviceDiscoveryType = properties.get(SERVICE_DISCOVERY);
             if (serviceDiscoveryType != null) {
-                SimpleServiceConfig.SimpleServiceDiscoveryConfig serviceDiscovery = new SimpleServiceConfig.SimpleServiceDiscoveryConfig(
+                SimpleServiceConfig.SimpleServiceDiscoveryConfig serviceDiscoveryConfig = new SimpleServiceConfig.SimpleServiceDiscoveryConfig(
                         serviceDiscoveryType, propertiesForPrefix(SERVICE_DISCOVERY, properties));
 
-                builder = builder.setServiceDiscovery(serviceDiscovery);
+                builder = builder.setServiceDiscovery(serviceDiscoveryConfig);
             }
 
             serviceConfigs.add(builder.build());

--- a/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
+++ b/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
@@ -51,7 +51,6 @@ public class ConsulServiceDiscovery extends CachingServiceDiscovery {
         this.secure = secure;
 
         ConsulClientOptions options = new ConsulClientOptions();
-        Map<String, String> parameters = config.parameters();
         Optional<String> host = get(config, "consul-host");
         if (host.isPresent()) {
             options.setHost(host.get());

--- a/test-utils/src/main/java/io/smallrye/stork/test/TestConfigProvider.java
+++ b/test-utils/src/main/java/io/smallrye/stork/test/TestConfigProvider.java
@@ -1,6 +1,7 @@
 package io.smallrye.stork.test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +54,9 @@ public class TestConfigProvider implements ConfigProvider {
 
                     @Override
                     public Map<String, String> parameters() {
+                        if (loadBalancerParams == null) {
+                            return Collections.emptyMap();
+                        }
                         return loadBalancerParams;
                     }
                 };
@@ -68,6 +72,9 @@ public class TestConfigProvider implements ConfigProvider {
 
                     @Override
                     public Map<String, String> parameters() {
+                        if (serviceDiscoveryParams == null) {
+                            return Collections.emptyMap();
+                        }
                         return serviceDiscoveryParams;
                     }
                 };


### PR DESCRIPTION
When only the service discovery strategy is configured without any other setting, a NPE happens. Fix for aligning with the prod behaviour, the only thing mandatory is the service discovery and load balancer, for the rest, Stork provides defaults values.