### PR TITLE
Implements a load-balancer following the "Power of Two Random Choices" strategy

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -113,6 +113,11 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.stork</groupId>
+                <artifactId>stork-load-balancer-power-of-two-choices</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.stork</groupId>
                 <artifactId>stork-microprofile-config</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -49,6 +49,24 @@
             <artifactId>stork-load-balancer-response-time</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-load-balancer-random</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-load-balancer-least-requests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-load-balancer-power-of-two-choices</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/docs/power-of-two-choices.md
+++ b/docs/power-of-two-choices.md
@@ -1,0 +1,34 @@
+# Power Of Two Choices Load Balancing
+
+The `power-of-two-choices` load balancing selects two random service instances and then chooses the one with the least inflight requests.
+It avoids the overhead of `least-requests` and the worst case for `random` where it selects a busy destination.
+
+This strategy acts as follows:
+
+1. when the selection happens, it picks two random instances from the list,
+2. it returns the least loaded instance (based on the number of inflight requests),
+3. when the operation completes, successfully or not, the number of inflight requests for the instance is decremented.
+
+Check [The Power of Two Random Choices](http://www.eecs.harvard.edu/~michaelm/NEWWORK/postscripts/twosurvey.pdf) paper to learn more about this pattern and the benefits.
+
+## Dependency
+
+First, you need to add the random load-balancer to your project:
+
+```xml
+<dependency>
+    <groupId>io.smallrye.stork</groupId>
+    <artifactId>stork-load-balancer-power-of-two-choices</artifactId>
+    <version>{{version.current}}</version>
+</dependency>
+```
+
+## Configuration
+
+For each service expected to use a random service selection, configure the `load-balancer` to be `power-of-two-choices`:
+
+```properties
+stork.my-service.service-discovery=...
+stork.my-service.service-discovery...=...
+stork.my-service.load-balancer=power-of-two-choices
+```

--- a/load-balancer/least-requests/src/main/java/io/smallrye/stork/loadbalancer/requests/LeastRequestsLoadBalancer.java
+++ b/load-balancer/least-requests/src/main/java/io/smallrye/stork/loadbalancer/requests/LeastRequestsLoadBalancer.java
@@ -10,7 +10,7 @@ import io.smallrye.stork.impl.ServiceInstanceWithStatGathering;
 
 public class LeastRequestsLoadBalancer implements LoadBalancer {
 
-    InflightRequestCollector collector = new InflightRequestCollector();
+    private final InflightRequestCollector collector = new InflightRequestCollector();
 
     @Override
     public ServiceInstance selectServiceInstance(Collection<ServiceInstance> serviceInstances) {

--- a/load-balancer/power-of-two-choices/pom.xml
+++ b/load-balancer/power-of-two-choices/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.stork</groupId>
+        <artifactId>stork-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>stork-load-balancer-power-of-two-choices</artifactId>
+
+    <name>SmallRye Stork Load Balancer : Power Of Two Choices</name>
+    <description>SmallRye Stork Load Balancer provider based selecting two random destinations and then selecting the one with the least assigned requests.</description>
+
+    <properties>
+        <revapi.skip>false</revapi.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-load-balancer-least-requests</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-service-discovery-static-list</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-configuration-generator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/load-balancer/power-of-two-choices/revapi.json
+++ b/load-balancer/power-of-two-choices/revapi.json
@@ -16,7 +16,7 @@
         "include": [
           {
             "matcher": "java-package",
-            "match": "/io\\.smallrye\\.stork\\.loadbalancer\\.requests(\\..*)?/"
+            "match": "/io\\.smallrye\\.stork\\.loadbalancer\\.poweroftwochoices(\\..*)?/"
           }
         ]
       }

--- a/load-balancer/power-of-two-choices/src/main/java/io/smallrye/stork/loadbalancer/poweroftwochoices/PowerOfTwoChoicesLoadBalancer.java
+++ b/load-balancer/power-of-two-choices/src/main/java/io/smallrye/stork/loadbalancer/poweroftwochoices/PowerOfTwoChoicesLoadBalancer.java
@@ -1,0 +1,51 @@
+package io.smallrye.stork.loadbalancer.poweroftwochoices;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+import io.smallrye.stork.api.LoadBalancer;
+import io.smallrye.stork.api.NoServiceInstanceFoundException;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.impl.ServiceInstanceWithStatGathering;
+import io.smallrye.stork.loadbalancer.requests.InflightRequestCollector;
+
+/**
+ * Select two random destinations and then select the one with the least assigned requests. This avoids the overhead of
+ * least-requests and the worst case for random where it selects a busy destination.
+ */
+public class PowerOfTwoChoicesLoadBalancer implements LoadBalancer {
+
+    private final InflightRequestCollector collector = new InflightRequestCollector();
+    private final Random random = new SecureRandom();
+
+    @Override
+    public ServiceInstance selectServiceInstance(Collection<ServiceInstance> serviceInstances) {
+        if (serviceInstances.isEmpty()) {
+            throw new NoServiceInstanceFoundException("No service instance found");
+        }
+
+        List<ServiceInstance> instances = new ArrayList<>(serviceInstances);
+        int count = instances.size();
+
+        if (count == 1) {
+            return instances.get(0);
+        }
+
+        ServiceInstance first = instances.get(random.nextInt(count));
+        ServiceInstance second = instances.get(random.nextInt(count));
+
+        int concurrencyOfFirst = collector.get(first.getId());
+        int concurrencyOfSecond = collector.get(second.getId());
+
+        if (concurrencyOfFirst < concurrencyOfSecond) {
+            collector.selected(first.getId());
+            return new ServiceInstanceWithStatGathering(first, collector);
+        } else {
+            collector.selected(second.getId());
+            return new ServiceInstanceWithStatGathering(second, collector);
+        }
+    }
+}

--- a/load-balancer/power-of-two-choices/src/main/java/io/smallrye/stork/loadbalancer/poweroftwochoices/PowerOfTwoChoicesLoadBalancerProvider.java
+++ b/load-balancer/power-of-two-choices/src/main/java/io/smallrye/stork/loadbalancer/poweroftwochoices/PowerOfTwoChoicesLoadBalancerProvider.java
@@ -1,0 +1,16 @@
+package io.smallrye.stork.loadbalancer.poweroftwochoices;
+
+import io.smallrye.stork.api.LoadBalancer;
+import io.smallrye.stork.api.ServiceDiscovery;
+import io.smallrye.stork.api.config.LoadBalancerType;
+import io.smallrye.stork.spi.LoadBalancerProvider;
+
+@LoadBalancerType("power-of-two-choices")
+public class PowerOfTwoChoicesLoadBalancerProvider
+        implements LoadBalancerProvider<PowerOfTwoChoicesLoadBalancerProviderConfiguration> {
+
+    public LoadBalancer createLoadBalancer(PowerOfTwoChoicesLoadBalancerProviderConfiguration config,
+            ServiceDiscovery serviceDiscovery) {
+        return new PowerOfTwoChoicesLoadBalancer();
+    }
+}

--- a/load-balancer/power-of-two-choices/src/test/java/io/smallrye/stork/loadbalancer/poweroftwochoices/EmptyServicesServiceDiscoveryProvider.java
+++ b/load-balancer/power-of-two-choices/src/test/java/io/smallrye/stork/loadbalancer/poweroftwochoices/EmptyServicesServiceDiscoveryProvider.java
@@ -1,0 +1,20 @@
+package io.smallrye.stork.loadbalancer.poweroftwochoices;
+
+import java.util.Collections;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.stork.api.ServiceDiscovery;
+import io.smallrye.stork.api.config.ServiceConfig;
+import io.smallrye.stork.api.config.ServiceDiscoveryType;
+import io.smallrye.stork.spi.ServiceDiscoveryProvider;
+import io.smallrye.stork.spi.StorkInfrastructure;
+
+@ServiceDiscoveryType("empty-services")
+public class EmptyServicesServiceDiscoveryProvider
+        implements ServiceDiscoveryProvider<EmptyServicesServiceDiscoveryProviderConfiguration> {
+    @Override
+    public ServiceDiscovery createServiceDiscovery(EmptyServicesServiceDiscoveryProviderConfiguration config,
+            String serviceName, ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
+        return () -> Uni.createFrom().item(Collections.emptyList());
+    }
+}

--- a/load-balancer/power-of-two-choices/src/test/java/io/smallrye/stork/loadbalancer/poweroftwochoices/PowerOfTwoChoicesLoadBalancerTest.java
+++ b/load-balancer/power-of-two-choices/src/test/java/io/smallrye/stork/loadbalancer/poweroftwochoices/PowerOfTwoChoicesLoadBalancerTest.java
@@ -1,0 +1,142 @@
+package io.smallrye.stork.loadbalancer.poweroftwochoices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.NoServiceInstanceFoundException;
+import io.smallrye.stork.api.Service;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.test.StorkTestUtils;
+import io.smallrye.stork.test.TestConfigProvider;
+
+public class PowerOfTwoChoicesLoadBalancerTest {
+    private static final Logger log = LoggerFactory.getLogger(PowerOfTwoChoicesLoadBalancerTest.class);
+
+    public static final String FST_SRVC_1 = "localhost:8080";
+    public static final String FST_SRVC_2 = "localhost:8081";
+    public static final String FST_SRVC_3 = "localhost:8082";
+    public static final String FST_SRVC_4 = "localhost:8083";
+    private Stork stork;
+
+    @BeforeEach
+    void setUp() {
+        TestConfigProvider.clear();
+        TestConfigProvider.addServiceConfig("first-service", "power-of-two-choices", "static",
+                null,
+                Map.of("address-list", String.format("%s,%s,%s,%s", FST_SRVC_1, FST_SRVC_2, FST_SRVC_3, FST_SRVC_4)));
+        TestConfigProvider.addServiceConfig("singleton-service", "power-of-two-choices",
+                "static", null,
+                Map.of("address-list", FST_SRVC_1));
+        TestConfigProvider.addServiceConfig("without-instances", "power-of-two-choices",
+                "empty-services", null, Collections.emptyMap());
+
+        stork = StorkTestUtils.getNewStorkInstance();
+    }
+
+    @Test
+    public void shouldSelectLessLoadedAmongTwoWhenAllLoaded() {
+        Service service = stork.getService("first-service");
+
+        List<ServiceInstance> instances = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            instances.add(selectInstance(service));
+        }
+
+        Random random = new Random();
+        // Start reporting
+        for (ServiceInstance instance : instances) {
+            if (random.nextInt(10) > 7) {
+                // Simulate failures
+                instance.recordResult(1000, new Exception("boom"));
+            } else {
+                instance.recordResult(1000, null);
+            }
+
+            ServiceInstance selected = selectInstance(service);
+            assertThat(selected).isNotNull();
+        }
+    }
+
+    @Test
+    void shouldPickAllServicesEvenWhenNotReporting() {
+        Service service = stork.getService("first-service");
+
+        Set<String> instances = new HashSet<>();
+
+        for (int i = 0; i < 100; i++) {
+            instances.add(asString(selectInstance(service)));
+        }
+
+        assertThat(instances).hasSize(4).contains(FST_SRVC_1, FST_SRVC_2, FST_SRVC_3, FST_SRVC_4);
+    }
+
+    @Test
+    void shouldThrowNoServiceInstanceOnNoInstances() throws ExecutionException, InterruptedException {
+        Service service = stork.getService("without-instances");
+
+        CompletableFuture<Throwable> result = new CompletableFuture<>();
+
+        service.selectServiceInstance().subscribe().with(v -> log.error("Unexpected successful result: {}", v),
+                result::complete);
+
+        await().atMost(Duration.ofSeconds(10)).until(result::isDone);
+        assertThat(result.get()).isInstanceOf(NoServiceInstanceFoundException.class);
+    }
+
+    @Test
+    void shouldReturnTheSingletonServiceWhenThereIsOnlyOne() {
+        Service service = stork.getService("singleton-service");
+
+        Set<String> set = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            set.add(asString(service.selectServiceInstance().await().atMost(Duration.ofMillis(5))));
+        }
+
+        assertThat(set).hasSize(1).contains(FST_SRVC_1);
+    }
+
+    @Test
+    void selectServicesRandomlyWhenConcurrencyIs0() {
+        Service service = stork.getService("first-service");
+
+        Set<String> instances = new HashSet<>();
+
+        for (int i = 0; i < 1000; i++) {
+            ServiceInstance instance = selectInstance(service);
+            instance.recordResult(1, null);
+            instances.add(asString(instance));
+        }
+
+        assertThat(instances).hasSize(4).contains(FST_SRVC_1, FST_SRVC_2, FST_SRVC_3, FST_SRVC_4);
+    }
+
+    private ServiceInstance selectInstance(Service service) {
+        return service.selectServiceInstance().await().atMost(Duration.ofSeconds(5));
+    }
+
+    private String asString(ServiceInstance serviceInstance) {
+        try {
+            return String.format("%s:%s", serviceInstance.getHost(), serviceInstance.getPort());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/load-balancer/random/src/main/java/io/smallrye/stork/loadbalancer/random/RandomLoadBalancer.java
+++ b/load-balancer/random/src/main/java/io/smallrye/stork/loadbalancer/random/RandomLoadBalancer.java
@@ -1,5 +1,6 @@
 package io.smallrye.stork.loadbalancer.random;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -11,7 +12,7 @@ import io.smallrye.stork.api.ServiceInstance;
 
 public class RandomLoadBalancer implements LoadBalancer {
 
-    private final Random random = new Random();
+    private final Random random = new SecureRandom();
 
     @Override
     public ServiceInstance selectServiceInstance(Collection<ServiceInstance> serviceInstances) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - Random: 'random.md'
     - Least Requests: 'least-requests.md'
     - Response Time: 'response-time.md'
+    - Power Of Two Choices: 'power-of-two-choices.md'
     - Custom: 'custom-load-balancer.md'
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <!-- Mostly for IDE to add the generated-sources to the classpath -->
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>add-generated-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources/annotations</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -289,6 +309,7 @@
         <module>load-balancer/response-time</module>
         <module>load-balancer/random</module>
         <module>load-balancer/least-requests</module>
+        <module>load-balancer/power-of-two-choices</module>
         <module>test-utils</module>
         <module>docs</module>
         <module>config-generator</module>

--- a/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulMetadataKey.java
+++ b/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulMetadataKey.java
@@ -8,7 +8,7 @@ public enum ConsulMetadataKey implements MetadataKey {
     META_CONSUL_SERVICE_NODE("consul-service-node"),
     META_CONSUL_SERVICE_NODE_ADDRESS("consul-service-node-address");
 
-    private String name;
+    private final String name;
 
     ConsulMetadataKey(String name) {
         this.name = name;

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesMetadataKey.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesMetadataKey.java
@@ -6,7 +6,7 @@ public enum KubernetesMetadataKey implements MetadataKey {
 
     META_K8S_SERVICE_ID("k8s-service-id");
 
-    private String name;
+    private final String name;
 
     KubernetesMetadataKey(String name) {
         this.name = name;

--- a/service-discovery/static-list/src/test/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryTest.java
+++ b/service-discovery/static-list/src/test/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryTest.java
@@ -54,4 +54,13 @@ public class StaticListServiceDiscoveryTest {
         assertThat(stork.getServiceOptional("missing")).isEmpty();
     }
 
+    @Test
+    void shouldFailOnInvalidFormat() {
+        TestConfigProvider.clear();
+        TestConfigProvider.addServiceConfig("broken-service", null, "static",
+                null, Map.of("address-list", "localhost:8080, localhost:8081, , "));
+        assertThatThrownBy(StorkTestUtils::getNewStorkInstance).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Address not parseable");
+    }
+
 }


### PR DESCRIPTION
Fix #220

Also:
- Use SecureRandom instead of Random
- Add a test in the static list discovery verifying that parsing errors are caught
- Add missing modules to the coverage
- Fix revapi package issues
