### PR TITLE
Replace raw types from Metadata to use properly parameterized types

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,6 +23,12 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/api/revapi.json
+++ b/api/revapi.json
@@ -34,6 +34,88 @@
       "minSeverity": "POTENTIALLY_BREAKING",
       "minCriticality": "documented",
       "differences": [
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::empty()",
+          "new": "method io.smallrye.stork.api.Metadata<? extends io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::empty()",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(===java.lang.Class<?>===)",
+          "new": "parameter <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(===java.lang.Class<K>===)",
+          "parameterIndex": "0",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<?>)",
+          "new": "method <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<K>)",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.elementNowParameterized",
+          "old": "method io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<?>)",
+          "new": "method <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<K>)",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterAdded",
+          "old": "method io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<?>)",
+          "new": "method <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<K>)",
+          "typeParameter": "K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(===java.lang.Class<?>===, java.util.Map<?, java.lang.Object>)",
+          "new": "parameter <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(===java.lang.Class<K>===, java.util.Map<K, java.lang.Object>)",
+          "parameterIndex": "0",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<?>, ===java.util.Map<?, java.lang.Object>===)",
+          "new": "parameter <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<K>, ===java.util.Map<K, java.lang.Object>===)",
+          "parameterIndex": "1",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<?>, java.util.Map<?, java.lang.Object>)",
+          "new": "method <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<K>, java.util.Map<K, java.lang.Object>)",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.elementNowParameterized",
+          "old": "method io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<?>, java.util.Map<?, java.lang.Object>)",
+          "new": "method <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<K>, java.util.Map<K, java.lang.Object>)",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterAdded",
+          "old": "method io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<?>, java.util.Map<?, java.lang.Object>)",
+          "new": "method <K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey> io.smallrye.stork.api.Metadata<K> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::of(java.lang.Class<K>, java.util.Map<K, java.lang.Object>)",
+          "typeParameter": "K extends java.lang.Enum<K> & io.smallrye.stork.api.MetadataKey",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method io.smallrye.stork.api.Metadata io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::with(T, java.lang.Object)",
+          "new": "method io.smallrye.stork.api.Metadata<T> io.smallrye.stork.api.Metadata<T extends java.lang.Enum<T>>::with(T, java.lang.Object)",
+          "justification": "Use proper parameterized types - it should be invisible to users, except less warnings"
+        }
       ]
     }
   },

--- a/api/src/main/java/io/smallrye/stork/api/Metadata.java
+++ b/api/src/main/java/io/smallrye/stork/api/Metadata.java
@@ -16,18 +16,18 @@ import java.util.Map;
  */
 public class Metadata<T extends Enum<T>> {
 
-    private final EnumMap<T, Object> metatada;
+    private final EnumMap<T, Object> metadata;
     private final Class<T> clazz;
-    private static final Metadata EMPTY = new Metadata(DefaultMetadataKey.class, Collections.emptyMap());
+    private static final Metadata<? extends MetadataKey> EMPTY = new Metadata<>(DefaultMetadataKey.class,
+            Collections.emptyMap());
 
-    private Metadata(Class<T> key, Map<T, Object> metatada) {
-        if (metatada.isEmpty()) {
-            this.metatada = new EnumMap<>(key);
-            this.clazz = key;
+    private Metadata(Class<T> key, Map<T, Object> metadata) {
+        if (metadata.isEmpty()) {
+            this.metadata = new EnumMap<>(key);
         } else {
-            this.metatada = new EnumMap<>(metatada);
-            this.clazz = key;
+            this.metadata = new EnumMap<>(metadata);
         }
+        this.clazz = key;
     }
 
     /**
@@ -35,7 +35,7 @@ public class Metadata<T extends Enum<T>> {
      *
      * @return the empty instance
      */
-    public static Metadata empty() {
+    public static Metadata<? extends MetadataKey> empty() {
         return EMPTY;
     }
 
@@ -46,11 +46,11 @@ public class Metadata<T extends Enum<T>> {
      *        must not contain multiple objects of the same class
      * @return the new metadata
      */
-    public static Metadata of(Class<?> key, Map<?, Object> metadata) {
+    public static <K extends Enum<K> & MetadataKey> Metadata<K> of(Class<K> key, Map<K, Object> metadata) {
         if (metadata == null) {
             throw new IllegalArgumentException("`metadata` must not be `null`");
         }
-        return new Metadata(key, metadata);
+        return new Metadata<>(key, metadata);
     }
 
     /**
@@ -59,11 +59,11 @@ public class Metadata<T extends Enum<T>> {
      * @param key the type of metadata, must not be {@code null}
      * @return the new metadata
      */
-    public static Metadata of(Class<?> key) {
+    public static <K extends Enum<K> & MetadataKey> Metadata<K> of(Class<K> key) {
         if (key == null) {
             throw new IllegalArgumentException("`key` must not be `null`");
         }
-        return new Metadata(key, Collections.emptyMap());
+        return new Metadata<>(key, Collections.emptyMap());
     }
 
     /**
@@ -74,26 +74,26 @@ public class Metadata<T extends Enum<T>> {
      * @param item the metadata to be added, must not be {@code null}.
      * @return the new instance of {@link Metadata}
      */
-    public Metadata with(T key, Object item) {
+    public Metadata<T> with(T key, Object item) {
         if (key == null) {
             throw new IllegalArgumentException("`key` must not be `null`");
         }
         if (item == null) {
             throw new IllegalArgumentException(key.name() + " should not be `null`");
         }
-        EnumMap<T, Object> copy = new EnumMap<>(metatada);
+        EnumMap<T, Object> copy = new EnumMap<>(metadata);
         copy.put(key, item);
-        return new Metadata(this.clazz, copy);
+        return new Metadata<>(this.clazz, copy);
     }
 
     public EnumMap<T, Object> getMetadata() {
-        return metatada;
+        return metadata;
     }
 
     public enum DefaultMetadataKey implements MetadataKey {
         GENERIC_METADATA_KEY("generic");
 
-        private String name;
+        private final String name;
 
         DefaultMetadataKey(String name) {
             this.name = name;

--- a/api/src/test/java/io/smallrye/stork/api/MetadataTest.java
+++ b/api/src/test/java/io/smallrye/stork/api/MetadataTest.java
@@ -1,0 +1,67 @@
+package io.smallrye.stork.api;
+
+import static io.smallrye.stork.api.Metadata.DefaultMetadataKey.GENERIC_METADATA_KEY;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MetadataTest {
+
+    @Test
+    void testEmpty() {
+        Metadata<?> metadata = Metadata.empty();
+        Assertions.assertNotNull(metadata);
+        Assertions.assertNull(metadata.getMetadata().get(GENERIC_METADATA_KEY));
+        Assertions.assertNotNull(GENERIC_METADATA_KEY.getName());
+    }
+
+    @Test
+    void testOf() {
+        Metadata<MyMetadataKey> metadata = Metadata.of(MyMetadataKey.class);
+        Assertions.assertNotNull(metadata);
+        metadata = metadata.with(MyMetadataKey.FOO, "hey!");
+        Assertions.assertNotNull(metadata);
+        Assertions.assertEquals("hey!", metadata.getMetadata().get(MyMetadataKey.FOO));
+    }
+
+    @Test
+    void testOfWithMap() {
+        Metadata<MyMetadataKey> metadata = Metadata.of(MyMetadataKey.class,
+                Map.of(MyMetadataKey.FOO, "Hey!", MyMetadataKey.BAR, 23));
+        Assertions.assertNotNull(metadata);
+        Assertions.assertEquals("Hey!", metadata.getMetadata().get(MyMetadataKey.FOO));
+        Assertions.assertEquals(23, metadata.getMetadata().get(MyMetadataKey.BAR));
+    }
+
+    @Test
+    void testOfWithEmptyMap() {
+        Metadata<MyMetadataKey> metadata = Metadata.of(MyMetadataKey.class, Collections.emptyMap());
+        Assertions.assertNotNull(metadata);
+        Assertions.assertNull(metadata.getMetadata().get(MyMetadataKey.FOO));
+        Assertions.assertNull(metadata.getMetadata().get(MyMetadataKey.BAR));
+    }
+
+    @Test
+    void shouldFailOnInvalidInputs() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Metadata.of(MyMetadataKey.class, null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Metadata.of(null));
+
+        Metadata<MyMetadataKey> metadata = Metadata.of(MyMetadataKey.class);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> metadata.with(MyMetadataKey.FOO, null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> metadata.with(null, "hello"));
+    }
+
+    public enum MyMetadataKey implements MetadataKey {
+        FOO,
+        BAR;
+
+        @Override
+        public String getName() {
+            return "foo";
+        }
+    }
+
+}

--- a/api/src/test/java/io/smallrye/stork/api/NoAcceptableServiceInstanceFoundExceptionTest.java
+++ b/api/src/test/java/io/smallrye/stork/api/NoAcceptableServiceInstanceFoundExceptionTest.java
@@ -1,0 +1,20 @@
+package io.smallrye.stork.api;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class NoAcceptableServiceInstanceFoundExceptionTest {
+
+    @Test
+    void canCreateNoAcceptableServiceInstanceFoundException() {
+        NoAcceptableServiceInstanceFoundException exception = new NoAcceptableServiceInstanceFoundException("missing");
+        Assertions.assertEquals("missing", exception.getMessage());
+        Assertions.assertNull(exception.getCause());
+
+        Exception cause = new ArithmeticException("boom");
+        exception = new NoAcceptableServiceInstanceFoundException("missing", cause);
+        Assertions.assertEquals("missing", exception.getMessage());
+        Assertions.assertEquals(cause, exception.getCause());
+    }
+
+}

--- a/api/src/test/java/io/smallrye/stork/api/NoServiceInstanceFoundExceptionTest.java
+++ b/api/src/test/java/io/smallrye/stork/api/NoServiceInstanceFoundExceptionTest.java
@@ -1,0 +1,20 @@
+package io.smallrye.stork.api;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class NoServiceInstanceFoundExceptionTest {
+
+    @Test
+    void canCreateNoServiceInstanceFoundException() {
+        NoServiceInstanceFoundException exception = new NoServiceInstanceFoundException("missing");
+        Assertions.assertEquals("missing", exception.getMessage());
+        Assertions.assertNull(exception.getCause());
+
+        Exception cause = new ArithmeticException("boom");
+        exception = new NoServiceInstanceFoundException("missing", cause);
+        Assertions.assertEquals("missing", exception.getMessage());
+        Assertions.assertEquals(cause, exception.getCause());
+    }
+
+}

--- a/api/src/test/java/io/smallrye/stork/api/ServiceInstanceTest.java
+++ b/api/src/test/java/io/smallrye/stork/api/ServiceInstanceTest.java
@@ -1,0 +1,59 @@
+package io.smallrye.stork.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify the default implementation for {@link ServiceInstance}.
+ */
+class ServiceInstanceTest {
+
+    ServiceInstance instance = new ServiceInstance() {
+        @Override
+        public long getId() {
+            return 0;
+        }
+
+        @Override
+        public String getHost() {
+            return null;
+        }
+
+        @Override
+        public int getPort() {
+            return 0;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+    };
+
+    @Test
+    void defaultMetadataShouldBeEmpty() {
+        Metadata<?> metadata = instance.getMetadata();
+        Assertions.assertNotNull(metadata);
+        Assertions.assertNull(metadata.getMetadata().get("foo"));
+    }
+
+    @Test
+    void defaultLabelsShouldBeEmpty() {
+        Map<String, String> labels = instance.getLabels();
+        Assertions.assertNotNull(labels);
+        Assertions.assertTrue(labels.isEmpty());
+    }
+
+    @Test
+    void defaultStatisticsAreDisabled() {
+        Assertions.assertFalse(instance.gatherStatistics());
+        Assertions.assertDoesNotThrow(() -> instance.recordResult(100, null));
+        Assertions.assertDoesNotThrow(() -> instance.recordResult(-1, null));
+        Assertions.assertDoesNotThrow(() -> instance.recordResult(100, new Exception("boom")));
+    }
+
+}

--- a/core/revapi.json
+++ b/core/revapi.json
@@ -16,7 +16,15 @@
         "include": [
           {
             "matcher": "java-package",
-            "match": "/io\\.smallrye\\.stork(\\..*)?/"
+            "match": "/io\\.smallrye\\.stork/"
+          },
+          {
+            "matcher": "java-package",
+            "match": "/io\\.smallrye\\.stork\\.integration(\\..*)?/"
+          },
+          {
+            "matcher": "java-package",
+            "match": "/io\\.smallrye\\.stork\\.utils(\\..*)?/"
           }
         ], "exclude": [
           "class io\\.smallrye\\.stork\\.impl\\..*"


### PR DESCRIPTION
It is a breaking change. However, the radius blast is minimal, if not invisible to the users (except fewer warnings). It will also prevent invalid access to the metadata. The revapi contains the changes and justifications.

This commit also adds a few tests to the API module. It also fixes the revapi configuration of the core module to avoid overlap with the API module.
