### PR TITLE
Deprecate the "secure" ServiceConfig attribute in favor to service discovery "secure" attributes.

### DIFF
--- a/api/revapi.json
+++ b/api/revapi.json
@@ -27,7 +27,22 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.stork.api.Service::<init>(java.lang.String, io.smallrye.stork.api.LoadBalancer, io.smallrye.stork.api.ServiceDiscovery, boolean, boolean)",
+        "new": "method void io.smallrye.stork.api.Service::<init>(java.lang.String, io.smallrye.stork.api.LoadBalancer, io.smallrye.stork.api.ServiceDiscovery, boolean)",
+        "justification": "Removal of the 'secure' parameter. Instead, use the `secure` attribute of each service discovery must be used, as the behavior depends on the service discovery code."
+      },
+      {
+        "ignore": true,
+        "code": "java.method.removed",
+        "old": "method boolean io.smallrye.stork.api.Service::isSecure()",
+        "justification": "Instead, use the `secure` attribute of each service discovery must be used, as the behavior depends on the service discovery code."
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/api/src/main/java/io/smallrye/stork/api/Service.java
+++ b/api/src/main/java/io/smallrye/stork/api/Service.java
@@ -17,14 +17,12 @@ public class Service {
     private final LoadBalancer loadBalancer;
     private final ServiceDiscovery serviceDiscovery;
     private final String serviceName;
-    private final boolean secure;
 
     public Service(String serviceName, LoadBalancer loadBalancer, ServiceDiscovery serviceDiscovery,
-            boolean secure, boolean requiresStrictRecording) {
+            boolean requiresStrictRecording) {
         this.loadBalancer = loadBalancer;
         this.serviceDiscovery = serviceDiscovery;
         this.serviceName = serviceName;
-        this.secure = secure;
         this.instanceSelectionLock = requiresStrictRecording ? new Semaphore(1) : null;
     }
 
@@ -139,7 +137,10 @@ public class Service {
         return serviceDiscovery;
     }
 
-    public boolean isSecure() {
-        return secure;
+    /**
+     * @return the service name.
+     */
+    public String getServiceName() {
+        return serviceName;
     }
 }

--- a/api/src/main/java/io/smallrye/stork/api/config/ServiceConfig.java
+++ b/api/src/main/java/io/smallrye/stork/api/config/ServiceConfig.java
@@ -29,7 +29,11 @@ public interface ServiceConfig {
      * Whether the communication should use a secure connection (e.g. HTTPS)
      * 
      * @return true if SSL, TLS, etc. should be used for the communication
+     * @deprecated Use the service discovery 'secure' attribute instead
      */
-    boolean secure();
+    @Deprecated
+    default boolean secure() {
+        return false;
+    }
 
 }

--- a/api/src/main/java/io/smallrye/stork/spi/config/SimpleServiceConfig.java
+++ b/api/src/main/java/io/smallrye/stork/spi/config/SimpleServiceConfig.java
@@ -36,11 +36,6 @@ public class SimpleServiceConfig implements ServiceConfig {
     }
 
     @Override
-    public boolean secure() {
-        return secure;
-    }
-
-    @Override
     public ServiceDiscoveryConfig serviceDiscovery() {
         return serviceDiscoveryConfig;
     }

--- a/core/src/test/java/io/smallrye/stork/test/AnchoredServiceDiscoveryProvider.java
+++ b/core/src/test/java/io/smallrye/stork/test/AnchoredServiceDiscoveryProvider.java
@@ -1,17 +1,23 @@
 package io.smallrye.stork.test;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.stork.api.ServiceDiscovery;
 import io.smallrye.stork.api.ServiceInstance;
 import io.smallrye.stork.api.config.ServiceConfig;
+import io.smallrye.stork.api.config.ServiceDiscoveryAttribute;
 import io.smallrye.stork.api.config.ServiceDiscoveryType;
 import io.smallrye.stork.spi.ServiceDiscoveryProvider;
 import io.smallrye.stork.spi.StorkInfrastructure;
 
 @ServiceDiscoveryType("fake")
+@ServiceDiscoveryAttribute(name = "secure", description = "mark the service secured")
 public class AnchoredServiceDiscoveryProvider
         implements ServiceDiscoveryProvider<AnchoredServiceDiscoveryProviderConfiguration> {
 
@@ -20,6 +26,13 @@ public class AnchoredServiceDiscoveryProvider
     @Override
     public ServiceDiscovery createServiceDiscovery(AnchoredServiceDiscoveryProviderConfiguration config, String serviceName,
             ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
+        if ("true".equalsIgnoreCase(config.getSecure())) {
+            return () -> Uni.createFrom().item(() -> services.stream().map(si -> {
+                ServiceInstance instance = mock(ServiceInstance.class);
+                when(instance.isSecure()).thenReturn(true);
+                return instance;
+            }).collect(Collectors.toList()));
+        }
         return () -> Uni.createFrom().item(() -> services);
     }
 }

--- a/microprofile/src/main/java/io/smallrye/stork/microprofile/MicroProfileConfigProvider.java
+++ b/microprofile/src/main/java/io/smallrye/stork/microprofile/MicroProfileConfigProvider.java
@@ -23,8 +23,6 @@ public class MicroProfileConfigProvider implements ConfigProvider {
     private static final String CONFIG_PROPERTY_PART_EXPRESSION = "\".*\"|[^.]+";
     private static final Pattern CONFIG_PROP_PART = Pattern.compile(CONFIG_PROPERTY_PART_EXPRESSION);
 
-    private static final String SECURE = "secure";
-
     public static final String LOAD_BALANCER = "load-balancer";
     public static final String LOAD_BALANCER_EMBEDDED = "load-balancer.type";
 
@@ -76,8 +74,6 @@ public class MicroProfileConfigProvider implements ConfigProvider {
 
             String serviceName = serviceEntry.getKey();
 
-            builder.setSecure(isSecureValueTrue(properties.get(SECURE), serviceName));
-
             String loadBalancerType = properties.get(LOAD_BALANCER);
             if (loadBalancerType == null) {
                 loadBalancerType = properties.get(LOAD_BALANCER_EMBEDDED);
@@ -103,21 +99,6 @@ public class MicroProfileConfigProvider implements ConfigProvider {
             }
 
             serviceConfigs.add(builder.build());
-        }
-    }
-
-    private boolean isSecureValueTrue(String secure, String serviceName) {
-        if (secure == null) {
-            return false;
-        }
-
-        if (Boolean.TRUE.toString().equalsIgnoreCase(secure)) {
-            return true;
-        } else if (Boolean.FALSE.toString().equalsIgnoreCase(secure)) {
-            return false;
-        } else {
-            throw new IllegalArgumentException("Unsupported value for the 'secure' property for service: '"
-                    + serviceName + "'. Expected 'true' or 'false'");
         }
     }
 

--- a/service-discovery/consul/revapi.json
+++ b/service-discovery/consul/revapi.json
@@ -24,7 +24,26 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscovery::<init>(java.lang.String, io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscoveryProviderConfiguration, io.vertx.core.Vertx, boolean)",
+        "new": "method void io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscovery::<init>(java.lang.String, io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscoveryProviderConfiguration, io.vertx.core.Vertx)",
+        "justification": "The 'secure' configuration is now passed as a part of the 'ConsulServiceDiscoveryProviderConfiguration'. Should not impact users."
+      },
+      {
+        "ignore": true,
+        "code": "java.annotation.attributeValueChanged",
+        "old": "class io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscoveryProvider",
+        "new": "class io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscoveryProvider",
+        "annotationType": "io.smallrye.stork.api.config.ServiceDiscoveryAttributes",
+        "attribute": "value",
+        "oldValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"consul-host\", description = \"The Consul host.\", defaultValue = \"localhost\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"consul-port\", description = \"The Consul port.\", defaultValue = \"8500\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"use-health-checks\", description = \"Whether to use health check.\", defaultValue = \"true\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"application\", description = \"The application name; if not defined Stork service name will be used.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"refresh-period\", description = \"Service discovery cache refresh period.\", defaultValue = \"5M\")}",
+        "newValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"consul-host\", description = \"The Consul host.\", defaultValue = \"localhost\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"consul-port\", description = \"The Consul port.\", defaultValue = \"8500\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"use-health-checks\", description = \"Whether to use health check.\", defaultValue = \"true\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"application\", description = \"The application name; if not defined Stork service name will be used.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"refresh-period\", description = \"Service discovery cache refresh period.\", defaultValue = \"5M\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"whether the connection with the service should be encrypted with TLS.\")}",
+        "justification": "Added the 'secure' attribute. Should not impact users."
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
+++ b/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscovery.java
@@ -32,11 +32,10 @@ public class ConsulServiceDiscovery extends CachingServiceDiscovery {
     private final boolean secure;
     private final boolean passing;
 
-    public ConsulServiceDiscovery(String serviceName, ConsulServiceDiscoveryProviderConfiguration config, Vertx vertx,
-            boolean secure) {
+    public ConsulServiceDiscovery(String serviceName, ConsulServiceDiscoveryProviderConfiguration config, Vertx vertx) {
         super(config.getRefreshPeriod());
         this.serviceName = serviceName;
-        this.secure = secure;
+        this.secure = isSecure(config);
         // TODO: more validation
         ConsulClientOptions options = new ConsulClientOptions();
         options.setHost(config.getConsulHost());
@@ -108,5 +107,9 @@ public class ConsulServiceDiscovery extends CachingServiceDiscovery {
             throw new IllegalArgumentException("Unable to parse the property `consul-port` to an integer from the " +
                     "service discovery configuration for service '" + name + "'", e);
         }
+    }
+
+    private boolean isSecure(ConsulServiceDiscoveryProviderConfiguration config) {
+        return config.getSecure() != null && Boolean.parseBoolean(config.getSecure());
     }
 }

--- a/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryProvider.java
+++ b/service-discovery/consul/src/main/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryProvider.java
@@ -13,14 +13,14 @@ import io.vertx.core.Vertx;
 @ServiceDiscoveryAttribute(name = "use-health-checks", description = "Whether to use health check.", defaultValue = "true")
 @ServiceDiscoveryAttribute(name = "application", description = "The application name; if not defined Stork service name will be used.")
 @ServiceDiscoveryAttribute(name = "refresh-period", description = "Service discovery cache refresh period.", defaultValue = "5M")
+@ServiceDiscoveryAttribute(name = "secure", description = "whether the connection with the service should be encrypted with TLS.")
 @ServiceDiscoveryType("consul")
 public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider<ConsulServiceDiscoveryProviderConfiguration> {
 
     @Override
     public ServiceDiscovery createServiceDiscovery(ConsulServiceDiscoveryProviderConfiguration config, String serviceName,
             ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
-        return new ConsulServiceDiscovery(serviceName, config, storkInfrastructure.get(Vertx.class, Vertx::vertx),
-                serviceConfig.secure());
+        return new ConsulServiceDiscovery(serviceName, config, storkInfrastructure.get(Vertx.class, Vertx::vertx));
 
     }
 }

--- a/service-discovery/eureka/revapi.json
+++ b/service-discovery/eureka/revapi.json
@@ -24,7 +24,26 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscovery::<init>(io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscoveryProviderConfiguration, java.lang.String, boolean, io.smallrye.stork.spi.StorkInfrastructure)",
+        "new": "method void io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscovery::<init>(io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscoveryProviderConfiguration, java.lang.String, io.smallrye.stork.spi.StorkInfrastructure)",
+        "justification": "The 'secure' configuration is now passed as a part of the 'EurekaServiceDiscoveryProviderConfiguration'. Should not impact users."
+      },
+      {
+        "ignore": true,
+        "code": "java.annotation.attributeValueChanged",
+        "old": "class io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscoveryProvider",
+        "new": "class io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscoveryProvider",
+        "annotationType": "io.smallrye.stork.api.config.ServiceDiscoveryAttributes",
+        "attribute": "value",
+        "oldValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-host\", description = \"The Eureka server host.\", required = true), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-port\", description = \"The Eureka server port.\", defaultValue = \"8761\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-context-path\", description = \"The Eureka server root context path.\", defaultValue = \"\/\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"application\", description = \"The Eureka application Id; if not defined Stork service name will be used\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-trust-all\", description = \"Enable\/Disable the TLS certificate verification\", defaultValue = \"false\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-tls\", description = \"Use TLS to connect to the Eureka server\", defaultValue = \"false\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"instance\", description = \"The Eureka application instance Id\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"refresh-period\", description = \"Service discovery cache refresh period.\", defaultValue = \"5M\")}",
+        "newValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-host\", description = \"The Eureka server host.\", required = true), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-port\", description = \"The Eureka server port.\", defaultValue = \"8761\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-context-path\", description = \"The Eureka server root context path.\", defaultValue = \"\/\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"application\", description = \"The Eureka application Id; if not defined Stork service name will be used\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-trust-all\", description = \"Enable\/Disable the TLS certificate verification\", defaultValue = \"false\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"eureka-tls\", description = \"Use TLS to connect to the Eureka server\", defaultValue = \"false\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"instance\", description = \"The Eureka application instance Id\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"refresh-period\", description = \"Service discovery cache refresh period.\", defaultValue = \"5M\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether is should select the secured endpoint of the retrieved services.\", defaultValue = \"false\")}",
+        "justification": "Added the 'secure' attribute. Should not impact users."
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/service-discovery/eureka/src/main/java/io/smallrye/stork/servicediscovery/eureka/EurekaServiceDiscovery.java
+++ b/service-discovery/eureka/src/main/java/io/smallrye/stork/servicediscovery/eureka/EurekaServiceDiscovery.java
@@ -35,10 +35,10 @@ public class EurekaServiceDiscovery extends CachingServiceDiscovery {
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private final Optional<String> instance;
 
-    public EurekaServiceDiscovery(EurekaServiceDiscoveryProviderConfiguration config, String serviceName, boolean secure,
+    public EurekaServiceDiscovery(EurekaServiceDiscoveryProviderConfiguration config, String serviceName,
             StorkInfrastructure infrastructure) {
         super(config.getRefreshPeriod());
-        this.secure = secure;
+        this.secure = isSecure(config);
         Vertx vertx = infrastructure.get(Vertx.class, Vertx::vertx);
 
         // Eureka instance
@@ -141,5 +141,9 @@ public class EurekaServiceDiscovery extends CachingServiceDiscovery {
                     "Unable to retrieve services from Eureka, expected as 200-OK response, but got " + resp.statusCode()
                             + ", body is: " + resp.bodyAsString());
         }
+    }
+
+    private boolean isSecure(EurekaServiceDiscoveryProviderConfiguration config) {
+        return config.getSecure() != null && Boolean.parseBoolean(config.getSecure());
     }
 }

--- a/service-discovery/eureka/src/main/java/io/smallrye/stork/servicediscovery/eureka/EurekaServiceDiscoveryProvider.java
+++ b/service-discovery/eureka/src/main/java/io/smallrye/stork/servicediscovery/eureka/EurekaServiceDiscoveryProvider.java
@@ -16,11 +16,12 @@ import io.smallrye.stork.spi.StorkInfrastructure;
 @ServiceDiscoveryAttribute(name = "eureka-tls", description = "Use TLS to connect to the Eureka server", defaultValue = "false")
 @ServiceDiscoveryAttribute(name = "instance", description = "The Eureka application instance Id")
 @ServiceDiscoveryAttribute(name = "refresh-period", description = "Service discovery cache refresh period.", defaultValue = "5M")
+@ServiceDiscoveryAttribute(name = "secure", description = "Whether is should select the secured endpoint of the retrieved services.", defaultValue = "false")
 public class EurekaServiceDiscoveryProvider implements ServiceDiscoveryProvider<EurekaServiceDiscoveryProviderConfiguration> {
 
     @Override
     public ServiceDiscovery createServiceDiscovery(EurekaServiceDiscoveryProviderConfiguration config, String serviceName,
             ServiceConfig serviceConfig, StorkInfrastructure infrastructure) {
-        return new EurekaServiceDiscovery(config, serviceName, serviceConfig.secure(), infrastructure);
+        return new EurekaServiceDiscovery(config, serviceName, infrastructure);
     }
 }

--- a/service-discovery/kubernetes/revapi.json
+++ b/service-discovery/kubernetes/revapi.json
@@ -24,7 +24,26 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscovery::<init>(java.lang.String, io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProviderConfiguration, io.vertx.core.Vertx, boolean)",
+        "new": "method void io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscovery::<init>(java.lang.String, io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProviderConfiguration, io.vertx.core.Vertx)",
+        "justification": "The 'secure' configuration is now passed as a part of the 'KubernetesServiceDiscoveryProviderConfiguration'. Should not impact users."
+      },
+      {
+        "ignore": true,
+        "code": "java.annotation.attributeValueChanged",
+        "old": "class io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProvider",
+        "new": "class io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProvider",
+        "annotationType": "io.smallrye.stork.api.config.ServiceDiscoveryAttributes",
+        "attribute": "value",
+        "oldValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"k8s-host\", description = \"The Kubernetes API host.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"k8s-namespace\", description = \"The namespace of the service. Use all to discover all namespaces.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"application\", description = \"The Eureka application Id; if not defined Stork service name will be used.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"refresh-period\", description = \"Service discovery cache refresh period.\", defaultValue = \"5M\")}",
+        "newValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"k8s-host\", description = \"The Kubernetes API host.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"k8s-namespace\", description = \"The namespace of the service. Use all to discover all namespaces.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"application\", description = \"The Eureka application Id; if not defined Stork service name will be used.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"refresh-period\", description = \"Service discovery cache refresh period.\", defaultValue = \"5M\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether the connection with the service should be encrypted with TLS.\")}",
+        "justification": "Added the 'secure' attribute. Should not impact users."
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
@@ -30,7 +30,6 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
 
     public static final String METADATA_NAME = "metadata.name";
     private final KubernetesClient client;
-    private final String serviceName;
     private String application;
     private final boolean allNamespaces;
     private final String namespace;
@@ -39,11 +38,9 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesServiceDiscovery.class);
 
-    public KubernetesServiceDiscovery(String serviceName, KubernetesServiceDiscoveryProviderConfiguration config, Vertx vertx,
-            boolean secure) {
+    public KubernetesServiceDiscovery(String serviceName, KubernetesServiceDiscoveryProviderConfiguration config, Vertx vertx) {
         super(config.getRefreshPeriod());
         Config base = Config.autoConfigure(null);
-        this.serviceName = serviceName;
         String masterUrl = config.getK8sHost() == null ? base.getMasterUrl() : config.getK8sHost();
         this.application = config.getApplication() == null ? serviceName : config.getApplication();
         this.namespace = config.getK8sNamespace() == null ? base.getNamespace() : config.getK8sNamespace();
@@ -58,9 +55,9 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
         Config k8sConfig = new ConfigBuilder(base)
                 .withMasterUrl(masterUrl)
                 .withNamespace(namespace).build();
-        client = new DefaultKubernetesClient(k8sConfig);
+        this.client = new DefaultKubernetesClient(k8sConfig);
         this.vertx = vertx;
-        this.secure = secure;
+        this.secure = isSecure(config);
     }
 
     @Override
@@ -160,6 +157,10 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
 
         }
         return serviceInstances;
+    }
+
+    private static boolean isSecure(KubernetesServiceDiscoveryProviderConfiguration config) {
+        return config.getSecure() != null && Boolean.parseBoolean(config.getSecure());
     }
 
 }

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryProvider.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryProvider.java
@@ -13,14 +13,14 @@ import io.vertx.core.Vertx;
 @ServiceDiscoveryAttribute(name = "k8s-namespace", description = "The namespace of the service. Use all to discover all namespaces.")
 @ServiceDiscoveryAttribute(name = "application", description = "The Eureka application Id; if not defined Stork service name will be used.")
 @ServiceDiscoveryAttribute(name = "refresh-period", description = "Service discovery cache refresh period.", defaultValue = "5M")
+@ServiceDiscoveryAttribute(name = "secure", description = "Whether the connection with the service should be encrypted with TLS.")
 public class KubernetesServiceDiscoveryProvider
         implements ServiceDiscoveryProvider<KubernetesServiceDiscoveryProviderConfiguration> {
 
     @Override
     public ServiceDiscovery createServiceDiscovery(KubernetesServiceDiscoveryProviderConfiguration config, String serviceName,
             ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
-        return new KubernetesServiceDiscovery(serviceName, config, storkInfrastructure.get(Vertx.class, Vertx::vertx),
-                serviceConfig.secure());
+        return new KubernetesServiceDiscovery(serviceName, config, storkInfrastructure.get(Vertx.class, Vertx::vertx));
 
     }
 }

--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
@@ -90,7 +90,46 @@ public class KubernetesServiceDiscoveryTest {
             Metadata<KubernetesMetadataKey> k8sMetadata = (Metadata<KubernetesMetadataKey>) metadata;
             assertThat(k8sMetadata.getMetadata()).containsKey(META_K8S_SERVICE_ID);
         });
+        assertThat(instances.get()).allSatisfy(si -> assertThat(si.isSecure()).isFalse());
+    }
 
+    @Test
+    void shouldHandleSecureAttribute() {
+
+        TestConfigProvider.addServiceConfig("svc", null, "kubernetes",
+                null, Map.of("k8s-host", k8sMasterUrl, "k8s-namespace", defaultNamespace, "secure", "true"));
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        String serviceName = "svc";
+        String[] ips = { "10.96.96.231", "10.96.96.232", "10.96.96.233" };
+
+        registerKubernetesService(serviceName, defaultNamespace, ips);
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Kubernetes", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).hasSize(3);
+        assertThat(instances.get().stream().map(ServiceInstance::getPort)).allMatch(p -> p == 8080);
+        assertThat(instances.get().stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("10.96.96.231",
+                "10.96.96.232", "10.96.96.233");
+        for (ServiceInstance serviceInstance : instances.get()) {
+            Map<String, String> labels = serviceInstance.getLabels();
+            assertThat(labels).contains(entry("app.kubernetes.io/name", "svc"),
+                    entry("app.kubernetes.io/version", "1.0"),
+                    entry("ui", "ui-" + ipAsSuffix(serviceInstance.getHost())));
+        }
+        instances.get().stream().map(ServiceInstance::getMetadata).forEach(metadata -> {
+            Metadata<KubernetesMetadataKey> k8sMetadata = (Metadata<KubernetesMetadataKey>) metadata;
+            assertThat(k8sMetadata.getMetadata()).containsKey(META_K8S_SERVICE_ID);
+        });
+        assertThat(instances.get()).allSatisfy(si -> assertThat(si.isSecure()).isTrue());
     }
 
     @Test

--- a/service-discovery/static-list/revapi.json
+++ b/service-discovery/static-list/revapi.json
@@ -24,7 +24,24 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.annotation.removed",
+        "old": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProvider",
+        "new": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProvider",
+        "annotation": "@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"address-list\", description = \"a comma-separated list of addresses\")",
+        "justification": "By adding a `ServiceDiscoveryAttribute` annotation, it uses the 'ServiceDiscoveryAttributes' container annotation. Should not impact users."
+      },
+      {
+        "ignore": true,
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProvider",
+        "new": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProvider",
+        "annotation": "@io.smallrye.stork.api.config.ServiceDiscoveryAttributes({@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"address-list\", description = \"A comma-separated list of addresses (host:port). The default port is 80.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether the connection with the service should be encrypted with TLS. Default is false, except if the host:port uses the port is 443.\")})",
+        "justification": "By adding a `ServiceDiscoveryAttribute` annotation, it uses the 'ServiceDiscoveryAttributes' container annotation. Should not impact users."
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProvider.java
+++ b/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProvider.java
@@ -16,7 +16,8 @@ import io.smallrye.stork.utils.ServiceInstanceIds;
 import io.smallrye.stork.utils.StorkAddressUtils;
 
 @ServiceDiscoveryType("static")
-@ServiceDiscoveryAttribute(name = "address-list", description = "a comma-separated list of addresses")
+@ServiceDiscoveryAttribute(name = "address-list", description = "A comma-separated list of addresses (host:port). The default port is 80.")
+@ServiceDiscoveryAttribute(name = "secure", description = "Whether the connection with the service should be encrypted with TLS. Default is false, except if the host:port uses the port is 443.")
 public class StaticListServiceDiscoveryProvider
         implements ServiceDiscoveryProvider<StaticListServiceDiscoveryProviderConfiguration> {
 
@@ -35,7 +36,7 @@ public class StaticListServiceDiscoveryProvider
                 HostAndPort hostAndPort = StorkAddressUtils.parseToHostAndPort(address, 80, serviceName);
                 addressList
                         .add(new DefaultServiceInstance(ServiceInstanceIds.next(), hostAndPort.host, hostAndPort.port,
-                                serviceConfig.secure()));
+                                isSecure(config.getSecure(), hostAndPort.port)));
             } catch (Exception e) {
                 throw new IllegalArgumentException(
                         "Address not parseable to URL: " + url + " for service " + serviceName);
@@ -43,5 +44,14 @@ public class StaticListServiceDiscoveryProvider
         }
 
         return new StaticListServiceDiscovery(addressList);
+    }
+
+    private boolean isSecure(String secureAttribute, int port) {
+        if (secureAttribute == null) {
+            return port == 443;
+        } else {
+            return Boolean.parseBoolean(secureAttribute);
+        }
+
     }
 }

--- a/test-utils/revapi.json
+++ b/test-utils/revapi.json
@@ -24,7 +24,15 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.stork.test.TestServiceDiscovery::<init>(io.smallrye.stork.test.TestServiceDiscovery1ProviderConfiguration, java.lang.String, boolean)",
+        "new": "method void io.smallrye.stork.test.TestServiceDiscovery::<init>(io.smallrye.stork.test.TestServiceDiscovery1ProviderConfiguration, java.lang.String)",
+        "justification": "Removal of the 'secure' parameter. Instead the 'secure' attribute of the service discovery should be used. Should not impact users."
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/test-utils/src/main/java/io/smallrye/stork/test/TestConfigProvider.java
+++ b/test-utils/src/main/java/io/smallrye/stork/test/TestConfigProvider.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import io.smallrye.stork.api.config.LoadBalancerConfig;
 import io.smallrye.stork.api.config.ServiceConfig;
@@ -26,22 +27,21 @@ public class TestConfigProvider implements ConfigProvider {
         return priority;
     }
 
+    @Deprecated
     public static void addServiceConfig(String name, String loadBalancer, String serviceDiscovery,
-            Map<String, String> loadBalancerParams, Map<String, String> serviceDiscoveryParams) {
-        addServiceConfig(name, loadBalancer, serviceDiscovery, loadBalancerParams, serviceDiscoveryParams, false);
+            Map<String, String> loadBalancerParams, Map<String, String> serviceDiscoveryParams, boolean secure) {
+        if (secure) {
+            serviceDiscoveryParams.put("secure", "true");
+        }
+        addServiceConfig(name, loadBalancer, serviceDiscovery, loadBalancerParams, serviceDiscoveryParams);
     }
 
     public static void addServiceConfig(String name, String loadBalancer, String serviceDiscovery,
-            Map<String, String> loadBalancerParams, Map<String, String> serviceDiscoveryParams, boolean secure) {
+            Map<String, String> loadBalancerParams, Map<String, String> serviceDiscoveryParams) {
         configs.add(new ServiceConfig() {
             @Override
             public String serviceName() {
                 return name;
-            }
-
-            @Override
-            public boolean secure() {
-                return secure;
             }
 
             @Override
@@ -54,10 +54,7 @@ public class TestConfigProvider implements ConfigProvider {
 
                     @Override
                     public Map<String, String> parameters() {
-                        if (loadBalancerParams == null) {
-                            return Collections.emptyMap();
-                        }
-                        return loadBalancerParams;
+                        return Objects.requireNonNullElse(loadBalancerParams, Collections.emptyMap());
                     }
                 };
             }
@@ -72,10 +69,7 @@ public class TestConfigProvider implements ConfigProvider {
 
                     @Override
                     public Map<String, String> parameters() {
-                        if (serviceDiscoveryParams == null) {
-                            return Collections.emptyMap();
-                        }
-                        return serviceDiscoveryParams;
+                        return Objects.requireNonNullElse(serviceDiscoveryParams, Collections.emptyMap());
                     }
                 };
             }

--- a/test-utils/src/main/java/io/smallrye/stork/test/TestServiceDiscovery.java
+++ b/test-utils/src/main/java/io/smallrye/stork/test/TestServiceDiscovery.java
@@ -11,7 +11,7 @@ public class TestServiceDiscovery implements ServiceDiscovery {
     private final TestServiceDiscovery1ProviderConfiguration config;
     private final String type;
 
-    public TestServiceDiscovery(TestServiceDiscovery1ProviderConfiguration config, String type, boolean secure) {
+    public TestServiceDiscovery(TestServiceDiscovery1ProviderConfiguration config, String type) {
         this.config = config;
         this.type = type;
     }

--- a/test-utils/src/main/java/io/smallrye/stork/test/TestServiceDiscovery1Provider.java
+++ b/test-utils/src/main/java/io/smallrye/stork/test/TestServiceDiscovery1Provider.java
@@ -17,7 +17,7 @@ public class TestServiceDiscovery1Provider implements ServiceDiscoveryProvider<T
     @Override
     public ServiceDiscovery createServiceDiscovery(TestServiceDiscovery1ProviderConfiguration config, String serviceName,
             ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
-        return new TestServiceDiscovery(config, TYPE, serviceConfig.secure());
+        return new TestServiceDiscovery(config, TYPE);
     }
 
 }

--- a/test-utils/src/main/java/io/smallrye/stork/test/TestServiceDiscovery2Provider.java
+++ b/test-utils/src/main/java/io/smallrye/stork/test/TestServiceDiscovery2Provider.java
@@ -16,6 +16,6 @@ public class TestServiceDiscovery2Provider implements ServiceDiscoveryProvider<T
     @Override
     public ServiceDiscovery createServiceDiscovery(TestServiceDiscovery2ProviderConfiguration config, String serviceName,
             ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
-        return new TestServiceDiscovery2(config, TYPE, serviceConfig.secure());
+        return new TestServiceDiscovery2(config, TYPE, false);
     }
 }


### PR DESCRIPTION
- Implement a backward-compatible way
- Add the "secure" attribute to all service discovery (with slightly different documentation)
- Add test to verify the previous behavior and new behavior
- Declare the log level stating that round-robin is used by default
