### PR TITLE
Add the `shuffle` attribute to the static service discovery provider

### DIFF
--- a/service-discovery/static-list/revapi.json
+++ b/service-discovery/static-list/revapi.json
@@ -24,7 +24,19 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.annotation.attributeValueChanged",
+        "old": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProvider",
+        "new": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProvider",
+        "annotationType": "io.smallrye.stork.api.config.ServiceDiscoveryAttributes",
+        "attribute": "value",
+        "oldValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"address-list\", description = \"A comma-separated list of addresses (host:port). The default port is 80.\", required = true), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether the connection with the service should be encrypted with TLS. Default is false, except if the host:port uses the port is 443.\")}",
+        "newValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"address-list\", description = \"A comma-separated list of addresses (host:port). The default port is 80.\", required = true), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether the connection with the service should be encrypted with TLS. Default is false, except if the host:port uses the port is 443.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"shuffle\", description = \"Whether the list of address must be shuffled to avoid using the first address on every startup.\", defaultValue = \"false\")}",
+        "justification": "Added the `shuffle` attribute"
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProvider.java
+++ b/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProvider.java
@@ -2,6 +2,7 @@ package io.smallrye.stork.servicediscovery.staticlist;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import io.smallrye.stork.api.ServiceDiscovery;
@@ -21,6 +22,7 @@ import io.smallrye.stork.utils.StorkAddressUtils;
 @ServiceDiscoveryType("static")
 @ServiceDiscoveryAttribute(name = "address-list", description = "A comma-separated list of addresses (host:port). The default port is 80.", required = true)
 @ServiceDiscoveryAttribute(name = "secure", description = "Whether the connection with the service should be encrypted with TLS. Default is false, except if the host:port uses the port is 443.")
+@ServiceDiscoveryAttribute(name = "shuffle", description = "Whether the list of address must be shuffled to avoid using the first address on every startup.", defaultValue = "false")
 public class StaticListServiceDiscoveryProvider
         implements ServiceDiscoveryProvider<StaticConfiguration> {
 
@@ -44,6 +46,10 @@ public class StaticListServiceDiscoveryProvider
                 throw new IllegalArgumentException(
                         "Address not parseable to URL: " + url + " for service " + serviceName);
             }
+        }
+
+        if (Boolean.parseBoolean(config.getShuffle())) {
+            Collections.shuffle(addressList);
         }
 
         return new StaticListServiceDiscovery(addressList);


### PR DESCRIPTION
Fix https://github.com/smallrye/smallrye-stork/issues/240
