### PR TITLE
refactor: rename class

### DIFF
--- a/api/src/main/java/io/smallrye/stork/spi/config/SimpleServiceConfig.java
+++ b/api/src/main/java/io/smallrye/stork/spi/config/SimpleServiceConfig.java
@@ -138,7 +138,7 @@ public class SimpleServiceConfig implements ServiceConfig {
      * An implementation of {@link ConfigWithType} using an unmodifiable {@link Map} as backend to store
      * the configuration.
      */
-    public static class SimpleConfigWithType implements ConfigWithType {
+    public static class SimpleServiceDiscoveryConfig implements ConfigWithType {
         private final String type;
         private final Map<String, String> parameters;
 
@@ -148,7 +148,7 @@ public class SimpleServiceConfig implements ServiceConfig {
          * @param type the type
          * @param parameters the configuration map
          */
-        public SimpleConfigWithType(String type, Map<String, String> parameters) {
+        public SimpleServiceDiscoveryConfig(String type, Map<String, String> parameters) {
             this.type = type;
             this.parameters = Collections.unmodifiableMap(parameters);
         }

--- a/core/src/main/java/io/smallrye/stork/Stork.java
+++ b/core/src/main/java/io/smallrye/stork/Stork.java
@@ -177,7 +177,7 @@ public final class Stork implements StorkServiceRegistry {
             // We do not know if we can add to the parameters, such create a new SimpleConfigWithType
             Map<String, String> newConfig = new HashMap<>(ConfigWithType.parameters());
             newConfig.put("secure", "true");
-            ConfigWithType = new SimpleServiceConfig.SimpleConfigWithType(serviceDiscoveryType, newConfig);
+            ConfigWithType = new SimpleServiceConfig.SimpleServiceDiscoveryConfig(serviceDiscoveryType, newConfig);
         }
 
         final var serviceDiscovery = serviceDiscoveryProvider.createServiceDiscovery(ConfigWithType,

--- a/microprofile/src/main/java/io/smallrye/stork/microprofile/MicroProfileConfigProvider.java
+++ b/microprofile/src/main/java/io/smallrye/stork/microprofile/MicroProfileConfigProvider.java
@@ -150,7 +150,7 @@ public class MicroProfileConfigProvider implements ConfigProvider {
             serviceDiscoveryType = properties.get(SERVICE_DISCOVERY_EMBEDDED);
         }
         if (serviceDiscoveryType != null) {
-            SimpleServiceConfig.SimpleConfigWithType ConfigWithType = new SimpleServiceConfig.SimpleConfigWithType(
+            SimpleServiceConfig.SimpleServiceDiscoveryConfig ConfigWithType = new SimpleServiceConfig.SimpleServiceDiscoveryConfig(
                     serviceDiscoveryType, propertiesForPrefix(SERVICE_DISCOVERY, properties));
 
             builder = builder.setServiceDiscovery(ConfigWithType);


### PR DESCRIPTION
I think this slipped through the cracks when refactoring and creating the ConfigWhithType. New name is more descriptive and aligned with the Load Balancer equivalent.
Once this will be released, [Quarkus Stork extension](https://github.com/aureamunoz/quarkus/blob/86a0fa19da718d76784a296842e97302fbde14f1/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigUtil.java#L19) will need to be refactored so to release in stork 1.3?