### PR TITLE
Fix missing attribute tables and footer image in doc

### DIFF
--- a/docs/docs/load-balancer/least-requests.md
+++ b/docs/docs/load-balancer/least-requests.md
@@ -40,4 +40,4 @@ For each service expected to use a least-response-time selection, configure the 
 [//]: # (Supported attributes are the following:)
 
 [//]: # ()
-[//]: # (--8<-- "load-balancer/least-requests/target/classes/META-INF/stork-docs/least-requests-lb-attributes.txt")
+[//]: # (--8<-- "../load-balancer/least-requests/target/classes/META-INF/stork-docs/least-requests-lb-attributes.txt")

--- a/docs/docs/load-balancer/power-of-two-choices.md
+++ b/docs/docs/load-balancer/power-of-two-choices.md
@@ -44,4 +44,4 @@ For each service expected to use a random service selection, configure the `load
 
 Supported attributes are the following:
 
---8<-- "load-balancer/power-of-two-choices/target/classes/META-INF/stork-docs/power-of-two-choices-lb-attributes.txt"
+--8<-- "../load-balancer/power-of-two-choices/target/classes/META-INF/stork-docs/power-of-two-choices-lb-attributes.txt"

--- a/docs/docs/load-balancer/random.md
+++ b/docs/docs/load-balancer/random.md
@@ -34,4 +34,4 @@ For each service expected to use a random service selection, configure the `load
 
 Supported attributes are the following:
 
---8<-- "load-balancer/random/target/classes/META-INF/stork-docs/random-lb-attributes.txt"
+--8<-- "../load-balancer/random/target/classes/META-INF/stork-docs/random-lb-attributes.txt"

--- a/docs/docs/load-balancer/response-time.md
+++ b/docs/docs/load-balancer/response-time.md
@@ -47,7 +47,7 @@ For each service expected to use a least-response-time selection, configure the 
 
 The following attributes are supported:
 
---8<-- "load-balancer/least-response-time/target/classes/META-INF/stork-docs/least-response-time-lb-attributes.txt"
+--8<-- "../load-balancer/least-response-time/target/classes/META-INF/stork-docs/least-response-time-lb-attributes.txt"
 
 ## Score calculation
 

--- a/docs/docs/load-balancer/sticky.md
+++ b/docs/docs/load-balancer/sticky.md
@@ -35,4 +35,4 @@ To use the `sticky` load service selection strategy, set the load balancer type 
 
 The following attributes are supported:
 
---8<-- "load-balancer/sticky/target/classes/META-INF/stork-docs/sticky-lb-attributes.txt"
+--8<-- "../load-balancer/sticky/target/classes/META-INF/stork-docs/sticky-lb-attributes.txt"

--- a/docs/docs/service-discovery/composite.md
+++ b/docs/docs/service-discovery/composite.md
@@ -43,4 +43,4 @@ Remember to define the services that make up your composite service.
 
 These are all the parameters of the composite service discovery:
 
---8<-- "service-discovery/composite/target/classes/META-INF/stork-docs/composite-sd-attributes.txt"
+--8<-- "../service-discovery/composite/target/classes/META-INF/stork-docs/composite-sd-attributes.txt"

--- a/docs/docs/service-discovery/consul.md
+++ b/docs/docs/service-discovery/consul.md
@@ -35,7 +35,7 @@ For each service that should get the service instances from Consul, configure th
 
 Consul service discovery is configured with the following parameters:
 
---8<-- "service-discovery/consul/target/classes/META-INF/stork-docs/consul-sd-attributes.txt"
+--8<-- "../service-discovery/consul/target/classes/META-INF/stork-docs/consul-sd-attributes.txt"
 
 ## Service registration
 
@@ -57,4 +57,4 @@ quarkus.stork.my-service.service-registrar.type=consul
 
 Consul service registrar is configured with the following parameters:
 
---8<-- "service-discovery/consul/target/classes/META-INF/stork-docs/consul-sr-attributes.txt"
+--8<-- "../service-discovery/consul/target/classes/META-INF/stork-docs/consul-sr-attributes.txt"

--- a/docs/docs/service-discovery/dns.md
+++ b/docs/docs/service-discovery/dns.md
@@ -55,4 +55,4 @@ All in all, your configuration could look as follows:
 
 All the available parameters are as follows:
 
---8<-- "service-discovery/dns/target/classes/META-INF/stork-docs/dns-sd-attributes.txt"
+--8<-- "../service-discovery/dns/target/classes/META-INF/stork-docs/dns-sd-attributes.txt"

--- a/docs/docs/service-discovery/eureka.md
+++ b/docs/docs/service-discovery/eureka.md
@@ -39,7 +39,7 @@ Stork looks for the service with the given name (`my-service` in the previous ex
 
 Supported attributes are the following:
 
---8<-- "service-discovery/eureka/target/classes/META-INF/stork-docs/eureka-sd-attributes.txt"
+--8<-- "../service-discovery/eureka/target/classes/META-INF/stork-docs/eureka-sd-attributes.txt"
 
 The `application` attribute is optional.
 It uses the Stork service name (`my-service` in the previous configuration) if not set.
@@ -74,4 +74,4 @@ quarkus.stork.my-service.service-registrar.eureka-port=8761
 
 Consul service registrar is configured with the following parameters:
 
---8<-- "service-discovery/eureka/target/classes/META-INF/stork-docs/eureka-sr-attributes.txt"
+--8<-- "../service-discovery/eureka/target/classes/META-INF/stork-docs/eureka-sr-attributes.txt"

--- a/docs/docs/service-discovery/kubernetes.md
+++ b/docs/docs/service-discovery/kubernetes.md
@@ -95,7 +95,7 @@ Then, it can select the instance.
 
 Supported attributes are the following:
 
---8<-- "service-discovery/kubernetes/target/classes/META-INF/stork-docs/kubernetes-sd-attributes.txt"
+--8<-- "../service-discovery/kubernetes/target/classes/META-INF/stork-docs/kubernetes-sd-attributes.txt"
 
 
 ## Caching the service instances
@@ -104,7 +104,7 @@ Contacting the cluster too much frequently can result in performance problems. I
 Moreover, the caching expiration has been also improved in order to only update the retrieved set of `ServiceInstance` if some of them changes and an event is emitted. 
 This is done by creating an [Informer](https://www.javadoc.io/static/io.fabric8/kubernetes-client-api/6.1.1/io/fabric8/kubernetes/client/informers/SharedIndexInformer.html), similar to a [Watch](https://www.javadoc.io/static/io.fabric8/kubernetes-client-api/6.1.1/io/fabric8/kubernetes/client/Watch.html),  able to observe the events on the service instances resources. 
 
---8<-- "src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java"
+--8<-- "../src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java"
 
 Note that: 
  - the cache is invalidated when an event is received. 

--- a/docs/docs/service-discovery/static-list.md
+++ b/docs/docs/service-discovery/static-list.md
@@ -33,4 +33,4 @@ For each service that should use the static list of service instances configure 
 
 These are all the static service discovery parameters:
 
---8<-- "service-discovery/static-list/target/classes/META-INF/stork-docs/static-sd-attributes.txt"
+--8<-- "../service-discovery/static-list/target/classes/META-INF/stork-docs/static-sd-attributes.txt"

--- a/docs/mkdocs-customizations/overrides/partials/copyright.html
+++ b/docs/mkdocs-customizations/overrides/partials/copyright.html
@@ -23,7 +23,7 @@
 <!-- Copyright and theme information, adapter to have the Red Hat footer -->
 <div class="md-copyright">
     <div class="md-copyright__highlight">
-        Sponsored by <a href="https://www.redhat.com"><img style="vertical-align: middle; height: 2.5em;" alt="Red Hat" src="{{ base_url }}/assets/redhat_reversed.svg"/></a> <br/>
+        Sponsored by <a href="https://www.redhat.com"><img style="vertical-align: middle; height: 2.5em;" alt="Red Hat" src="{{ base_url }}/images/redhat_reversed.svg"/></a> <br/>
         <a href="https://creativecommons.org/licenses/by/3.0/">CC by 3.0</a> |
         <a href="https://www.redhat.com/en/about/privacy-policy">Privacy Policy</a>
     </div>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,6 +3,7 @@ repo_url: https://github.com/smallrye/smallrye-stork
 edit_uri: edit/main/docs/
 docs_dir: docs
 
+
 nav:
   - Overview: 'index.md'
   - Concepts: 'concepts.md'
@@ -26,14 +27,9 @@ nav:
     - Sticky: 'load-balancer/sticky.md'
     - Custom Load Balancer: 'load-balancer/custom-load-balancer.md'
 
-
-copyright: >-
-  Sponsored by <a href="https://www.redhat.com"><img style="vertical-align: middle; height: 2.5em;" alt="Red Hat" src="./images/redhat_reversed.svg"/></a> <br/>
-  <a href="https://creativecommons.org/licenses/by/3.0/">CC by 3.0</a> |
-  <a href="https://www.redhat.com/en/about/privacy-policy">Privacy Policy</a>
-
 theme:
   name: material
+  custom_dir: mkdocs-customizations/overrides
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
- Configure the footer overrides
- Fix paths to attribute tables
