### PR TITLE
Revert to SLF4J 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@
         <version.testcontainers>1.17.6</version.testcontainers>
 
         <kubernetes-client.version>6.2.0</kubernetes-client.version>
-        <version.slf4j>2.0.4</version.slf4j>
+        <!-- we cannot update to 2.x as jboss-logging does not support SLF4J 2 for now -->
+        <version.slf4j>1.7.36</version.slf4j>
         <version.mockito>4.9.0</version.mockito>
         <version.jackson>2.14.1</version.jackson>
 


### PR DESCRIPTION
Quarkus uses jboss-logging, which does not yet support the 2.x version.

Fix #422
