### PR TITLE
Stork 2.x 

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>stork-api</artifactId>

--- a/api/src/main/java/io/smallrye/stork/spi/config/SimpleServiceConfig.java
+++ b/api/src/main/java/io/smallrye/stork/spi/config/SimpleServiceConfig.java
@@ -46,7 +46,7 @@ public class SimpleServiceConfig implements ServiceConfig {
     public static class Builder {
         String serviceName;
         ConfigWithType loadBalancerConfig;
-        ConfigWithType ConfigWithType;
+        ConfigWithType configWithType;
         boolean secure;
 
         /**
@@ -67,7 +67,7 @@ public class SimpleServiceConfig implements ServiceConfig {
          * @return the current builder
          */
         public Builder setServiceDiscovery(ConfigWithType serviceDiscovery) {
-            ConfigWithType = serviceDiscovery;
+            configWithType = serviceDiscovery;
             return this;
         }
 
@@ -99,7 +99,7 @@ public class SimpleServiceConfig implements ServiceConfig {
          * @return the built config
          */
         public SimpleServiceConfig build() {
-            return new SimpleServiceConfig(serviceName, loadBalancerConfig, ConfigWithType);
+            return new SimpleServiceConfig(serviceName, loadBalancerConfig, configWithType);
         }
     }
 

--- a/api/src/main/java/io/smallrye/stork/spi/internal/ServiceDiscoveryLoader.java
+++ b/api/src/main/java/io/smallrye/stork/spi/internal/ServiceDiscoveryLoader.java
@@ -7,7 +7,7 @@ import io.smallrye.stork.spi.ElementWithType;
 import io.smallrye.stork.spi.StorkInfrastructure;
 
 /**
- * Used by stork internals to generate service loader for LoadBalancerProvider.
+ * Used by stork internals to generate service loader for ServiceDiscoveryProvider.
  */
 public interface ServiceDiscoveryLoader extends ElementWithType {
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>io.smallrye.stork</groupId>
     <artifactId>stork-bom</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>SmallRye Stork : BOM</name>

--- a/config-generator/pom.xml
+++ b/config-generator/pom.xml
@@ -21,6 +21,11 @@
             <artifactId>stork-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <scope>provided</scope>

--- a/config-generator/pom.xml
+++ b/config-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>stork-configuration-generator</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>stork-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.stork</groupId>
             <artifactId>stork-configuration-generator</artifactId>
             <scope>provided</scope>
@@ -63,6 +67,21 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>stork-core</artifactId>

--- a/core/revapi.json
+++ b/core/revapi.json
@@ -34,10 +34,11 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.method.numberOfParametersChanged",
-        "old": "method java.time.Duration io.smallrye.stork.utils.DurationUtils::parseDuration(java.lang.String)",
-        "new": "method java.time.Duration io.smallrye.stork.utils.DurationUtils::parseDuration(java.lang.String, java.lang.String)",
-        "justification": "Parameter name added to the `parseDuration` method. The old version assumed the parsing is done for refresh-period which is not always true"
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.impl.RoundRobinLoadBalancerProviderLoader",
+        "new": "class io.smallrye.stork.impl.RoundRobinLoadBalancerProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "Load Balancer can now be CDI beans"
       }
     ]
   }

--- a/core/src/main/java/io/smallrye/stork/Stork.java
+++ b/core/src/main/java/io/smallrye/stork/Stork.java
@@ -142,7 +142,7 @@ public final class Stork implements StorkServiceRegistry {
 
     private void extendWithCdiLoaders(Map<String, ServiceDiscoveryLoader> serviceDiscoveryLoaders,
             Map<String, LoadBalancerLoader> loadBalancerLoaders, Map<String, ServiceRegistrarLoader> registrarLoaders) {
-        CDI cdi = null;
+        CDI cdi;
         try {
             cdi = CDI.current();
         } catch (IllegalStateException e) {
@@ -167,7 +167,6 @@ public final class Stork implements StorkServiceRegistry {
             providers.addAll(cdi.select(ConfigProvider.class).stream().collect(Collectors.toList()));
         } catch (IllegalStateException e) {
             // Ignored - no cdi.
-            e.printStackTrace();
         }
         Optional<ConfigProvider> highestPrioConfigProvider = providers.stream()
                 .max(Comparator.comparingInt(ConfigProvider::priority));

--- a/core/src/test/java/io/smallrye/stork/test/AnchoredServiceDiscoveryProvider.java
+++ b/core/src/test/java/io/smallrye/stork/test/AnchoredServiceDiscoveryProvider.java
@@ -5,7 +5,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.stork.api.ServiceDiscovery;
@@ -18,18 +22,31 @@ import io.smallrye.stork.spi.StorkInfrastructure;
 
 @ServiceDiscoveryType("fake")
 @ServiceDiscoveryAttribute(name = "secure", description = "mark the service secured")
+@ApplicationScoped
 public class AnchoredServiceDiscoveryProvider
         implements ServiceDiscoveryProvider<FakeConfiguration> {
 
     static final List<ServiceInstance> services = new ArrayList<>();
 
+    @Inject
+    MyDataBean bean;
+
     @Override
     public ServiceDiscovery createServiceDiscovery(FakeConfiguration config, String serviceName,
             ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
+        if (bean != null) {
+            for (ServiceInstance service : services) {
+                when(service.getLabels()).thenReturn(Map.of("label", bean.value()));
+            }
+        }
+
         if ("true".equalsIgnoreCase(config.getSecure())) {
             return () -> Uni.createFrom().item(() -> services.stream().map(si -> {
                 ServiceInstance instance = mock(ServiceInstance.class);
                 when(instance.isSecure()).thenReturn(true);
+                if (bean != null) {
+                    when(instance.getLabels()).thenReturn(Map.of("label", bean.value()));
+                }
                 return instance;
             }).collect(Collectors.toList()));
         }

--- a/core/src/test/java/io/smallrye/stork/test/MockLoadBalancerProvider.java
+++ b/core/src/test/java/io/smallrye/stork/test/MockLoadBalancerProvider.java
@@ -2,12 +2,15 @@ package io.smallrye.stork.test;
 
 import static org.mockito.Mockito.mock;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 import io.smallrye.stork.api.LoadBalancer;
 import io.smallrye.stork.api.ServiceDiscovery;
 import io.smallrye.stork.api.config.LoadBalancerType;
 import io.smallrye.stork.spi.LoadBalancerProvider;
 
 @LoadBalancerType("fake-selector")
+@ApplicationScoped
 public class MockLoadBalancerProvider implements LoadBalancerProvider<FakeSelectorConfiguration> {
 
     @Override

--- a/core/src/test/java/io/smallrye/stork/test/MyDataBean.java
+++ b/core/src/test/java/io/smallrye/stork/test/MyDataBean.java
@@ -1,0 +1,18 @@
+package io.smallrye.stork.test;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MyDataBean {
+
+    private String value;
+
+    public void set(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return this.value;
+    }
+
+}

--- a/core/src/test/java/io/smallrye/stork/test/StorkWithCDITest.java
+++ b/core/src/test/java/io/smallrye/stork/test/StorkWithCDITest.java
@@ -1,0 +1,479 @@
+package io.smallrye.stork.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.NoSuchServiceDefinitionException;
+import io.smallrye.stork.api.ServiceDefinition;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.api.config.ConfigWithType;
+import io.smallrye.stork.api.config.ServiceConfig;
+import io.smallrye.stork.impl.RoundRobinLoadBalancer;
+import io.smallrye.stork.impl.RoundRobinLoadBalancerProvider;
+import io.smallrye.stork.spi.config.ConfigProvider;
+
+@SuppressWarnings("unchecked")
+public class StorkWithCDITest extends WeldTestBase {
+
+    private static final ConfigWithType FAKE_SERVICE_DISCOVERY_CONFIG = new ConfigWithType() {
+
+        @Override
+        public String type() {
+            return "fake";
+        }
+
+        @Override
+        public Map<String, String> parameters() {
+            return Collections.emptyMap();
+        }
+    };
+
+    private static final ConfigWithType FAKE_SECURE_SERVICE_DISCOVERY_CONFIG = new ConfigWithType() {
+
+        @Override
+        public String type() {
+            return "fake";
+        }
+
+        @Override
+        public Map<String, String> parameters() {
+            return Map.of("secure", "true");
+        }
+    };
+
+    private static final ConfigWithType SERVICE_DISCOVERY_CONFIG_WITH_INVALID_PROVIDER = new ConfigWithType() {
+
+        @Override
+        public String type() {
+            return "non-existent";
+        }
+
+        @Override
+        public Map<String, String> parameters() {
+            return Collections.emptyMap();
+        }
+    };
+
+    private static final ConfigWithType FAKE_LOAD_BALANCER_CONFIG = new ConfigWithType() {
+
+        @Override
+        public String type() {
+            return "fake-selector";
+        }
+
+        @Override
+        public Map<String, String> parameters() {
+            return Collections.emptyMap();
+        }
+    };
+
+    private static final ConfigWithType LOAD_BALANCER_WITH_INVALID_PROVIDER = new ConfigWithType() {
+
+        @Override
+        public String type() {
+            return "non-existent";
+        }
+
+        @Override
+        public Map<String, String> parameters() {
+            return Collections.emptyMap();
+        }
+    };
+
+    @BeforeEach
+    public void init() {
+        TestEnv.configurations.clear();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        Stork.shutdown();
+        close();
+        AnchoredServiceDiscoveryProvider.services.clear();
+        configurations.clear();
+    }
+
+    @Test
+    void initWithoutConfigProvider() {
+        run();
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        assertThat(stork.getServiceOptional("anything")).isEmpty();
+    }
+
+    public static final List<ServiceConfig> configurations = new ArrayList<>();
+
+    @Test
+    void initWithoutServiceDiscoveryOrLoadBalancer() {
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+        Assertions.assertDoesNotThrow(() -> Stork.initialize());
+        Stork stork = Stork.getInstance();
+        Assertions.assertTrue(stork.getServiceOptional("missing").isEmpty());
+        Assertions.assertThrows(NoSuchServiceDefinitionException.class, () -> stork.getService("missing"));
+    }
+
+    @ApplicationScoped
+    @Typed(ConfigProvider.class)
+    public static class MyConfigProvider implements ConfigProvider {
+
+        @Override
+        public List<ServiceConfig> getConfigs() {
+            return new ArrayList<>(configurations);
+        }
+
+        @Override
+        public int priority() {
+            return 5;
+        }
+    }
+
+    @Test
+    public void initializationWithTwoConfigProviders() {
+        weld.addBeanClasses(ServiceAConfigProvider.class, ServiceBConfigProvider.class);
+        run();
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        Assertions.assertTrue(stork.getServiceOptional("a").isEmpty());
+
+        Assertions.assertTrue(stork.getServiceOptional("missing").isEmpty());
+        Assertions.assertTrue(stork.getServiceOptional("b").isPresent());
+        Assertions.assertNotNull(stork.getService("b"));
+    }
+
+    @ApplicationScoped
+    public static class ServiceAConfigProvider implements ConfigProvider {
+
+        @Override
+        public List<ServiceConfig> getConfigs() {
+            ServiceConfig service = new FakeServiceConfig("a", FAKE_SERVICE_DISCOVERY_CONFIG, null);
+            return List.of(service);
+        }
+
+        @Override
+        public int priority() {
+            return 5;
+        }
+    }
+
+    @ApplicationScoped
+    public static class ServiceBConfigProvider implements ConfigProvider {
+
+        @Override
+        public List<ServiceConfig> getConfigs() {
+            ServiceConfig service = new FakeServiceConfig("b", FAKE_SERVICE_DISCOVERY_CONFIG, null);
+            return List.of(service);
+        }
+
+        @Override
+        public int priority() {
+            return 100;
+        }
+    }
+
+    @Test
+    public void testServiceConfigWithoutServiceDiscovery() {
+        run();
+        Stork.initialize();
+        assertThatThrownBy(() -> Stork.getInstance().defineIfAbsent("a", ServiceDefinition.of(null)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testServiceWithoutServiceDiscoveryType() {
+        configurations.add(new FakeServiceConfig("a", new ConfigWithType() {
+            @Override
+            public String type() {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> parameters() {
+                return null;
+            }
+        }, null));
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+
+        Assertions.assertThrows(IllegalArgumentException.class, Stork::initialize);
+    }
+
+    @Test
+    public void testServiceWithServiceDiscoveryButNoMatchingProvider() {
+        configurations.add(new FakeServiceConfig("a", SERVICE_DISCOVERY_CONFIG_WITH_INVALID_PROVIDER, null));
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+        Assertions.assertThrows(IllegalArgumentException.class, Stork::initialize);
+    }
+
+    @Test
+    public void testWithLoadBalancerButNoMatchingProvider() {
+        configurations
+                .add(new FakeServiceConfig("a", FAKE_SERVICE_DISCOVERY_CONFIG, LOAD_BALANCER_WITH_INVALID_PROVIDER));
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+        Assertions.assertThrows(IllegalArgumentException.class, Stork::initialize);
+    }
+
+    @Test
+    public void testWithServiceDiscoveryAndASingleServiceInstance() {
+        configurations.add(new FakeServiceConfig("a",
+                FAKE_SERVICE_DISCOVERY_CONFIG, null));
+        ServiceInstance instance = mock(ServiceInstance.class);
+        AnchoredServiceDiscoveryProvider.services.add(instance);
+        weld.addBeanClass(AnchoredServiceDiscoveryProvider.class);
+
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+
+        String v = UUID.randomUUID().toString();
+        setDataBeanValue(v);
+
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        Assertions.assertTrue(stork.getServiceOptional("a").isPresent());
+        Assertions.assertNotNull(stork.getService("a").getServiceDiscovery());
+        Assertions.assertNotNull(stork.getService("a").getLoadBalancer());
+        Assertions.assertEquals(v,
+                stork.getService("a").selectInstance().await().indefinitely().getLabels().get("label"));
+    }
+
+    @Test
+    public void testWithLegacySecureServiceDiscovery() {
+        configurations.add(new FakeSecureServiceConfig("s",
+                FAKE_SERVICE_DISCOVERY_CONFIG, null));
+        ServiceInstance instance = mock(ServiceInstance.class);
+        AnchoredServiceDiscoveryProvider.services.add(instance);
+        weld.addBeanClass(AnchoredServiceDiscoveryProvider.class);
+
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+
+        String v = UUID.randomUUID().toString();
+        setDataBeanValue(v);
+
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        Assertions.assertTrue(stork.getServiceOptional("s").isPresent());
+        Assertions.assertNotNull(stork.getService("s").getServiceDiscovery());
+        Assertions.assertNotNull(stork.getService("s").getLoadBalancer());
+        Assertions.assertTrue(stork.getService("s").selectInstance().await().indefinitely().isSecure());
+        Assertions.assertEquals(v,
+                stork.getService("s").selectInstance().await().indefinitely().getLabels().get("label"));
+
+    }
+
+    @Test
+    public void testWithSecureServiceDiscovery() {
+        configurations.add(new FakeServiceConfig("s",
+                FAKE_SECURE_SERVICE_DISCOVERY_CONFIG, null));
+        ServiceInstance instance = mock(ServiceInstance.class);
+        AnchoredServiceDiscoveryProvider.services.add(instance);
+        weld.addBeanClass(AnchoredServiceDiscoveryProvider.class);
+
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+
+        String v = UUID.randomUUID().toString();
+        setDataBeanValue(v);
+
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        Assertions.assertTrue(stork.getServiceOptional("s").isPresent());
+        Assertions.assertNotNull(stork.getService("s").getServiceDiscovery());
+        Assertions.assertNotNull(stork.getService("s").getLoadBalancer());
+        Assertions.assertTrue(stork.getService("s").selectInstance().await().indefinitely().isSecure());
+        Assertions.assertEquals(v,
+                stork.getService("s").selectInstance().await().indefinitely().getLabels().get("label"));
+    }
+
+    @Test
+    public void testWithServiceDiscoveryAndATwoServiceInstances() {
+        configurations.add(new FakeServiceConfig("a",
+                FAKE_SERVICE_DISCOVERY_CONFIG, null));
+        ServiceInstance instance1 = mock(ServiceInstance.class);
+        ServiceInstance instance2 = mock(ServiceInstance.class);
+        AnchoredServiceDiscoveryProvider.services.add(instance1);
+        AnchoredServiceDiscoveryProvider.services.add(instance2);
+
+        weld.addBeanClass(AnchoredServiceDiscoveryProvider.class);
+
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+
+        String v = UUID.randomUUID().toString();
+        setDataBeanValue(v);
+
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        Assertions.assertTrue(stork.getServiceOptional("a").isPresent());
+        Assertions.assertNotNull(stork.getService("a").getServiceDiscovery());
+        Assertions.assertTrue(stork.getService("a").getInstances().await().indefinitely().contains(instance1));
+        Assertions.assertTrue(stork.getService("a").getInstances().await().indefinitely().contains(instance2));
+        Assertions.assertNotNull(stork.getService("a").getLoadBalancer());
+        Assertions.assertEquals(v, stork.getService("a").selectInstance().await().indefinitely().getLabels().get("label"));
+        Assertions.assertEquals(v, stork.getService("a").selectInstance().await().indefinitely().getLabels().get("label"));
+    }
+
+    @Test
+    public void testWithLoadBalancer() {
+        configurations.add(new FakeServiceConfig("a",
+                FAKE_SERVICE_DISCOVERY_CONFIG, FAKE_LOAD_BALANCER_CONFIG));
+        weld.addBeanClass(AnchoredServiceDiscoveryProvider.class);
+        weld.addBeanClass(MockLoadBalancerProvider.class);
+        weld.addBeanClass(AnchoredServiceDiscoveryProviderLoader.class);
+        weld.addBeanClass(MockLoadBalancerProviderLoader.class);
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+
+        String v = UUID.randomUUID().toString();
+        setDataBeanValue(v);
+
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        Assertions.assertTrue(stork.getServiceOptional("a").isPresent());
+        Assertions.assertNotNull(stork.getService("a").getLoadBalancer());
+    }
+
+    @Test
+    public void testWithDefaultLoadBalancer() {
+        ServiceInstance instance1 = mock(ServiceInstance.class);
+        ServiceInstance instance2 = mock(ServiceInstance.class);
+        ServiceInstance instance3 = mock(ServiceInstance.class);
+        AnchoredServiceDiscoveryProvider.services.add(instance1);
+        AnchoredServiceDiscoveryProvider.services.add(instance2);
+        AnchoredServiceDiscoveryProvider.services.add(instance3);
+
+        configurations.add(new FakeServiceConfig("a",
+                FAKE_SERVICE_DISCOVERY_CONFIG, null));
+
+        weld.addBeanClass(AnchoredServiceDiscoveryProvider.class);
+
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+
+        String v = UUID.randomUUID().toString();
+        setDataBeanValue(v);
+
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        Assertions.assertEquals(instance1, stork.getService("a").selectInstance().await().indefinitely());
+        Assertions.assertEquals(instance2, stork.getService("a").selectInstance().await().indefinitely());
+        Assertions.assertEquals(instance3, stork.getService("a").selectInstance().await().indefinitely());
+        Assertions.assertEquals(instance1, stork.getService("a").selectInstance().await().indefinitely());
+        Assertions.assertEquals(instance2, stork.getService("a").selectInstance().await().indefinitely());
+        Assertions.assertTrue(stork.getServiceOptional("a").isPresent());
+        Assertions.assertTrue(stork.getService("a").getLoadBalancer() instanceof RoundRobinLoadBalancer);
+    }
+
+    @Test
+    public void testWithExplicitConfigurationOfTheRoundRobinLoadBalancer() {
+        ServiceInstance instance1 = mock(ServiceInstance.class);
+        ServiceInstance instance2 = mock(ServiceInstance.class);
+        ServiceInstance instance3 = mock(ServiceInstance.class);
+        when(instance1.getId()).thenReturn(1L);
+        when(instance2.getId()).thenReturn(2L);
+        when(instance3.getId()).thenReturn(3L);
+        AnchoredServiceDiscoveryProvider.services.add(instance1);
+        AnchoredServiceDiscoveryProvider.services.add(instance2);
+        AnchoredServiceDiscoveryProvider.services.add(instance3);
+
+        configurations.add(new FakeServiceConfig("a",
+                FAKE_SERVICE_DISCOVERY_CONFIG, new ConfigWithType() {
+                    @Override
+                    public String type() {
+                        return RoundRobinLoadBalancerProvider.ROUND_ROBIN_TYPE;
+                    }
+
+                    @Override
+                    public Map<String, String> parameters() {
+                        return Collections.emptyMap();
+                    }
+                }));
+
+        weld.addBeanClass(AnchoredServiceDiscoveryProvider.class);
+        weld.addBeanClass(MyConfigProvider.class);
+        run();
+
+        String v = UUID.randomUUID().toString();
+        setDataBeanValue(v);
+
+        Stork.initialize();
+        Stork stork = Stork.getInstance();
+        Assertions.assertEquals(1L, stork.getService("a").selectInstance().await().indefinitely().getId());
+        Assertions.assertEquals(2L, stork.getService("a").selectInstance().await().indefinitely().getId());
+        Assertions.assertEquals(3L, stork.getService("a").selectInstance().await().indefinitely().getId());
+        Assertions.assertEquals(1L, stork.getService("a").selectInstance().await().indefinitely().getId());
+        Assertions.assertEquals(2L, stork.getService("a").selectInstance().await().indefinitely().getId());
+        Assertions.assertTrue(stork.getServiceOptional("a").isPresent());
+        Assertions.assertTrue(stork.getService("a").getLoadBalancer() instanceof RoundRobinLoadBalancer);
+    }
+
+    private static class FakeServiceConfig implements ServiceConfig {
+
+        private final String name;
+        private final ConfigWithType lb;
+        private final ConfigWithType sd;
+
+        private FakeServiceConfig(String name, ConfigWithType sd, ConfigWithType lb) {
+            this.name = name;
+            this.lb = lb;
+            this.sd = sd;
+        }
+
+        @Override
+        public String serviceName() {
+            return name;
+        }
+
+        @Override
+        public ConfigWithType loadBalancer() {
+            return lb;
+        }
+
+        @Override
+        public ConfigWithType serviceDiscovery() {
+            return sd;
+        }
+
+        @Override
+        public boolean secure() {
+            return false;
+        }
+    }
+
+    private static class FakeSecureServiceConfig extends FakeServiceConfig {
+
+        private FakeSecureServiceConfig(String name, ConfigWithType sd, ConfigWithType lb) {
+            super(name, sd, lb);
+        }
+
+        @Override
+        public boolean secure() {
+            return true;
+        }
+    }
+
+    private void setDataBeanValue(String v) {
+        CDI.current().select(MyDataBean.class).get().set(v);
+    }
+
+}

--- a/core/src/test/java/io/smallrye/stork/test/WeldTestBase.java
+++ b/core/src/test/java/io/smallrye/stork/test/WeldTestBase.java
@@ -1,0 +1,34 @@
+package io.smallrye.stork.test;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+
+public class WeldTestBase {
+
+    Weld weld;
+    WeldContainer container;
+
+    public WeldTestBase() {
+        weld = new Weld();
+        weld.addBeanClass(MyDataBean.class);
+        TestEnv.configurations.clear();
+    }
+
+    public void run() {
+        container = weld.initialize();
+    }
+
+    public void close() {
+        if (container != null) {
+            container.close();
+        } else {
+            weld.shutdown();
+        }
+        TestEnv.configurations.clear();
+    }
+
+    public <T> T get(Class<T> clazz) {
+        return container.select(clazz).get();
+    }
+
+}

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>stork-coverage</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>stork-doc</artifactId>
 

--- a/docs/snippets/examples/HelloClient.java
+++ b/docs/snippets/examples/HelloClient.java
@@ -1,12 +1,13 @@
 package examples;
 
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+
 
 @Path("/")
 @RegisterRestClient(baseUri = "stork://hello-service/hello")

--- a/load-balancer/least-requests/pom.xml
+++ b/load-balancer/least-requests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/load-balancer/least-requests/revapi.json
+++ b/load-balancer/least-requests/revapi.json
@@ -27,20 +27,11 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.loadbalancer.requests.LeastRequestsConfiguration",
-        "new": "class io.smallrye.stork.loadbalancer.requests.LeastRequestsConfiguration",
-        "interface": "io.smallrye.stork.api.config.LoadBalancerConfig",
-        "justification": "The name of the implemented interface has changed."
-
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.loadbalancer.requests.LeastRequestsLoadBalancerProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.LoadBalancerConfig===, io.smallrye.stork.api.ServiceDiscovery)",
-        "new": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.loadbalancer.requests.LeastRequestsLoadBalancerProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.ConfigWithType===, io.smallrye.stork.api.ServiceDiscovery)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.loadbalancer.requests.LeastRequestsLoadBalancerProviderLoader",
+        "new": "class io.smallrye.stork.loadbalancer.requests.LeastRequestsLoadBalancerProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/load-balancer/least-response-time/pom.xml
+++ b/load-balancer/least-response-time/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>stork-load-balancer-least-response-time</artifactId>

--- a/load-balancer/least-response-time/revapi.json
+++ b/load-balancer/least-response-time/revapi.json
@@ -27,19 +27,11 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.loadbalancer.leastresponsetime.LeastResponseTimeConfiguration",
-        "new": "class io.smallrye.stork.loadbalancer.leastresponsetime.LeastResponseTimeConfiguration",
-        "interface": "io.smallrye.stork.api.config.LoadBalancerConfig",
-        "justification": "The name of the implemented interface has changed."
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.loadbalancer.leastresponsetime.LeastResponseTimeLoadBalancerProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.LoadBalancerConfig===, io.smallrye.stork.api.ServiceDiscovery)",
-        "new": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.loadbalancer.leastresponsetime.LeastResponseTimeLoadBalancerProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.ConfigWithType===, io.smallrye.stork.api.ServiceDiscovery)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.loadbalancer.leastresponsetime.LeastResponseTimeLoadBalancerProviderLoader",
+        "new": "class io.smallrye.stork.loadbalancer.leastresponsetime.LeastResponseTimeLoadBalancerProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/load-balancer/power-of-two-choices/pom.xml
+++ b/load-balancer/power-of-two-choices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>stork-load-balancer-power-of-two-choices</artifactId>

--- a/load-balancer/power-of-two-choices/revapi.json
+++ b/load-balancer/power-of-two-choices/revapi.json
@@ -27,19 +27,11 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.loadbalancer.poweroftwochoices.PowerOfTwoChoicesConfiguration",
-        "new": "class io.smallrye.stork.loadbalancer.poweroftwochoices.PowerOfTwoChoicesConfiguration",
-        "interface": "io.smallrye.stork.api.config.LoadBalancerConfig",
-        "justification": "The name of the implemented interface has changed."
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.loadbalancer.poweroftwochoices.PowerOfTwoChoicesLoadBalancerProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.LoadBalancerConfig===, io.smallrye.stork.api.ServiceDiscovery)",
-        "new": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.loadbalancer.poweroftwochoices.PowerOfTwoChoicesLoadBalancerProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.ConfigWithType===, io.smallrye.stork.api.ServiceDiscovery)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.loadbalancer.poweroftwochoices.PowerOfTwoChoicesLoadBalancerProviderLoader",
+        "new": "class io.smallrye.stork.loadbalancer.poweroftwochoices.PowerOfTwoChoicesLoadBalancerProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/load-balancer/random/pom.xml
+++ b/load-balancer/random/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/load-balancer/random/revapi.json
+++ b/load-balancer/random/revapi.json
@@ -27,19 +27,11 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.loadbalancer.random.RandomConfiguration",
-        "new": "class io.smallrye.stork.loadbalancer.random.RandomConfiguration",
-        "interface": "io.smallrye.stork.api.config.LoadBalancerConfig",
-        "justification": "The name of the implemented interface has changed."
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.loadbalancer.random.RandomLoadBalancerProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.LoadBalancerConfig===, io.smallrye.stork.api.ServiceDiscovery)",
-        "new": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.loadbalancer.random.RandomLoadBalancerProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.ConfigWithType===, io.smallrye.stork.api.ServiceDiscovery)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.loadbalancer.random.RandomLoadBalancerProviderLoader",
+        "new": "class io.smallrye.stork.loadbalancer.random.RandomLoadBalancerProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/load-balancer/sticky/pom.xml
+++ b/load-balancer/sticky/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/load-balancer/sticky/revapi.json
+++ b/load-balancer/sticky/revapi.json
@@ -30,7 +30,14 @@
       "minSeverity": "POTENTIALLY_BREAKING",
       "minCriticality": "documented",
       "differences": [
-
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "old": "class io.smallrye.stork.loadbalancer.random.StickyLoadBalancerProviderLoader",
+          "new": "class io.smallrye.stork.loadbalancer.random.StickyLoadBalancerProviderLoader",
+          "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+          "justification": "The loaders are now also exposed as CDI beans"
+        }
       ]
     }
   },

--- a/microprofile/pom.xml
+++ b/microprofile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>stork-microprofile-config</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,12 @@
                 <version>${version.weld}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-junit5</artifactId>
+                <version>4.0.0.Final</version>
+                <scope>test</scope>
+            </dependency>
 
             <!-- Dependencies provided by the project -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
 
     <parent>
         <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-parent</artifactId>
+        <artifactId>smallrye-jakarta-parent</artifactId>
         <version>37</version>
     </parent>
 
     <groupId>io.smallrye.stork</groupId>
     <artifactId>stork-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>SmallRye Service Discovery : Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <version.slf4j>1.7.36</version.slf4j>
         <version.mockito>4.9.0</version.mockito>
         <version.jackson>2.14.1</version.jackson>
+        <version.weld>5.1.0.Final</version.weld>
 
         <revapi-maven-plugin.version>0.15.0</revapi-maven-plugin.version>
         <revapi-java.version>0.28.0</revapi-java.version>
@@ -100,6 +101,13 @@
                 <artifactId>microprofile-config-api</artifactId>
                 <version>${version.microprofile-config-api}</version>
             </dependency>
+
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>4.0.1</version>
+            </dependency>
+
             <!-- Jackson dependencies, imported as a BOM -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
@@ -162,6 +170,30 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-inline</artifactId>
                 <version>${version.mockito}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-core</artifactId>
+                <version>${version.weld}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-spi</artifactId>
+                <version>5.0.SP3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-api</artifactId>
+                <version>5.0.SP3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-core-impl</artifactId>
+                <version>${version.weld}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/service-discovery/composite/pom.xml
+++ b/service-discovery/composite/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-discovery/composite/revapi.json
+++ b/service-discovery/composite/revapi.json
@@ -27,19 +27,11 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.servicediscovery.composite.CompositeConfiguration",
-        "new": "class io.smallrye.stork.servicediscovery.composite.CompositeConfiguration",
-        "interface": "io.smallrye.stork.api.config.ServiceDiscoveryConfig",
-        "justification": "The name of the implemented interface has changed."
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.composite.CompositeServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ServiceDiscoveryConfig===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "new": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.composite.CompositeServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ConfigWithType===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.servicediscovery.composite.CompositeServiceDiscoveryProviderLoader",
+        "new": "class io.smallrye.stork.servicediscovery.composite.CompositeServiceDiscoveryProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/service-discovery/consul/pom.xml
+++ b/service-discovery/consul/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-discovery/consul/revapi.json
+++ b/service-discovery/consul/revapi.json
@@ -27,20 +27,19 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.servicediscovery.consul.ConsulConfiguration",
-        "new": "class io.smallrye.stork.servicediscovery.consul.ConsulConfiguration",
-        "interface": "io.smallrye.stork.api.config.ServiceDiscoveryConfig",
-        "justification": "The name of the implemented interface has changed."
-
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscoveryProviderLoader",
+        "new": "class io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscoveryProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       },
       {
         "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ServiceDiscoveryConfig===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "new": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.consul.ConsulServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ConfigWithType===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.servicediscovery.consul.ConsulServiceRegistrarProviderLoader",
+        "new": "class io.smallrye.stork.servicediscovery.consul.ConsulServiceRegistrarProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/service-discovery/dns/pom.xml
+++ b/service-discovery/dns/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-discovery/dns/revapi.json
+++ b/service-discovery/dns/revapi.json
@@ -24,7 +24,16 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.servicediscovery.dns.DnsServiceDiscoveryProviderLoader",
+        "new": "class io.smallrye.stork.servicediscovery.dns.DnsServiceDiscoveryProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/service-discovery/eureka/pom.xml
+++ b/service-discovery/eureka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-discovery/eureka/revapi.json
+++ b/service-discovery/eureka/revapi.json
@@ -26,21 +26,21 @@
     "minCriticality" : "documented",
     "differences" : [ {
       "ignore": true,
-      "code": "java.class.noLongerImplementsInterface",
-      "old": "class io.smallrye.stork.servicediscovery.eureka.EurekaConfiguration",
-      "new": "class io.smallrye.stork.servicediscovery.eureka.EurekaConfiguration",
-      "interface": "io.smallrye.stork.api.config.ServiceDiscoveryConfig",
-      "justification": "The name of the implemented interface has changed."
-
+      "code": "java.annotation.added",
+      "old": "class io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscoveryProviderLoader",
+      "new": "class io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscoveryProviderLoader",
+      "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+      "justification": "The loaders are now also exposed as CDI beans"
     },
       {
         "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ServiceDiscoveryConfig===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "new": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.eureka.EurekaServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ConfigWithType===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
-      }]
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.servicediscovery.eureka.EurekaServiceRegistrarProviderLoader",
+        "new": "class io.smallrye.stork.servicediscovery.eureka.EurekaServiceRegistrarProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/service-discovery/kubernetes/pom.xml
+++ b/service-discovery/kubernetes/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-discovery/kubernetes/revapi.json
+++ b/service-discovery/kubernetes/revapi.json
@@ -27,20 +27,11 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.servicediscovery.kubernetes.KubernetesConfiguration",
-        "new": "class io.smallrye.stork.servicediscovery.kubernetes.KubernetesConfiguration",
-        "interface": "io.smallrye.stork.api.config.ServiceDiscoveryConfig",
-        "justification": "The name of the implemented interface has changed."
-
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ServiceDiscoveryConfig===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "new": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ConfigWithType===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProviderLoader",
+        "new": "class io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/service-discovery/static-list/pom.xml
+++ b/service-discovery/static-list/pom.xml
@@ -58,6 +58,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/service-discovery/static-list/pom.xml
+++ b/service-discovery/static-list/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-discovery/static-list/revapi.json
+++ b/service-discovery/static-list/revapi.json
@@ -27,31 +27,19 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.annotation.attributeValueChanged",
+        "code": "java.annotation.added",
         "old": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProvider",
         "new": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProvider",
-        "annotationType": "io.smallrye.stork.api.config.ServiceDiscoveryAttributes",
-        "attribute": "value",
-        "oldValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"address-list\", description = \"A comma-separated list of addresses (host:port). The default port is 80.\", required = true), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether the connection with the service should be encrypted with TLS. Default is false, except if the host:port uses the port is 443.\")}",
-        "newValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"address-list\", description = \"A comma-separated list of addresses (host:port). The default port is 80.\", required = true), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether the connection with the service should be encrypted with TLS. Default is false, except if the host:port uses the port is 443.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"shuffle\", description = \"Whether the list of address must be shuffled to avoid using the first address on every startup.\", defaultValue = \"false\")}",
-        "justification": "Added the `shuffle` attribute"
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "the loaders are now also exposed as CDI beans"
       },
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.servicediscovery.staticlist.StaticConfiguration",
-        "new": "class io.smallrye.stork.servicediscovery.staticlist.StaticConfiguration",
-        "interface": "io.smallrye.stork.api.config.ServiceDiscoveryConfig",
-        "justification": "The name of the implemented interface has changed."
-
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ServiceDiscoveryConfig===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "new": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ConfigWithType===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProviderLoader",
+        "new": "class io.smallrye.stork.servicediscovery.staticlist.StaticListServiceDiscoveryProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "the loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProvider.java
+++ b/service-discovery/static-list/src/main/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProvider.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 import io.smallrye.stork.api.ServiceDiscovery;
 import io.smallrye.stork.api.config.ServiceConfig;
 import io.smallrye.stork.api.config.ServiceDiscoveryAttribute;
@@ -23,6 +25,7 @@ import io.smallrye.stork.utils.StorkAddressUtils;
 @ServiceDiscoveryAttribute(name = "address-list", description = "A comma-separated list of addresses (host:port). The default port is 80.", required = true)
 @ServiceDiscoveryAttribute(name = "secure", description = "Whether the connection with the service should be encrypted with TLS. Default is false, except if the host:port uses the port is 443.")
 @ServiceDiscoveryAttribute(name = "shuffle", description = "Whether the list of address must be shuffled to avoid using the first address on every startup.", defaultValue = "false")
+@ApplicationScoped
 public class StaticListServiceDiscoveryProvider
         implements ServiceDiscoveryProvider<StaticConfiguration> {
 

--- a/service-discovery/static-list/src/test/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryCDITest.java
+++ b/service-discovery/static-list/src/test/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryCDITest.java
@@ -1,0 +1,96 @@
+package io.smallrye.stork.servicediscovery.staticlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.NoSuchServiceDefinitionException;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.test.StorkTestUtils;
+import io.smallrye.stork.test.TestConfigProviderBean;
+
+@ExtendWith(WeldJunit5Extension.class)
+public class StaticListServiceDiscoveryCDITest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(TestConfigProviderBean.class,
+            StaticListServiceDiscoveryProviderLoader.class);
+
+    @Inject
+    TestConfigProviderBean config;
+    Stork stork;
+
+    @BeforeEach
+    void setUp() {
+        config.clear();
+        config.addServiceConfig("first-service", null, "static",
+                null, Map.of("address-list", "localhost:8080, localhost:8081"));
+        config.addServiceConfig("second-service", null, "static",
+                null, Map.of("address-list", "localhost:8082", "secure", "true"));
+        config.addServiceConfig("third-service", null, "static",
+                null, Map.of("address-list", "localhost:8083"));
+        config.addServiceConfig("secured-service", null, "static",
+                null, Map.of("address-list", "localhost:443, localhost"));
+
+        this.stork = StorkTestUtils.getNewStorkInstance();
+
+    }
+
+    @Test
+    void testSecureDetection() {
+        List<ServiceInstance> instances = stork.getService("secured-service").getInstances().await()
+                .atMost(Duration.ofSeconds(5));
+
+        assertThat(instances).hasSize(2);
+        assertThat(instances.get(0).isSecure()).isTrue();
+        assertThat(instances.get(1).isSecure()).isFalse();
+
+        instances = stork.getService("second-service").getInstances().await().atMost(Duration.ofSeconds(5));
+        assertThat(instances).hasSize(1);
+        assertThat(instances.get(0).isSecure()).isTrue();
+    }
+
+    @Test
+    void shouldGetAllServiceInstances() {
+        List<ServiceInstance> serviceInstances = stork.getService("first-service")
+                .getInstances()
+                .await().atMost(Duration.ofSeconds(5));
+
+        assertThat(serviceInstances).hasSize(2);
+        assertThat(serviceInstances.stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("localhost",
+                "localhost");
+        assertThat(serviceInstances.stream().map(ServiceInstance::getPort)).containsExactlyInAnyOrder(8080,
+                8081);
+        assertThat(serviceInstances.stream().map(ServiceInstance::isSecure)).allSatisfy(b -> assertThat(b).isFalse());
+    }
+
+    @Test
+    void shouldFailOnMissingService() {
+        assertThatThrownBy(() -> stork.getService("missing")).isInstanceOf(NoSuchServiceDefinitionException.class);
+        assertThat(stork.getServiceOptional("missing")).isEmpty();
+    }
+
+    @Test
+    void shouldFailOnInvalidFormat() {
+        config.clear();
+        config.addServiceConfig("broken-service", null, "static",
+                null, Map.of("address-list", "localhost:8080, localhost:8081, , "));
+        Stork.shutdown();
+        assertThatThrownBy(StorkTestUtils::getNewStorkInstance).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Address not parseable");
+    }
+
+}

--- a/service-discovery/static-list/src/test/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProgrammaticApiCDITest.java
+++ b/service-discovery/static-list/src/test/java/io/smallrye/stork/servicediscovery/staticlist/StaticListServiceDiscoveryProgrammaticApiCDITest.java
@@ -1,0 +1,121 @@
+package io.smallrye.stork.servicediscovery.staticlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.NoSuchServiceDefinitionException;
+import io.smallrye.stork.api.ServiceDefinition;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.test.StorkTestUtils;
+import io.smallrye.stork.test.TestConfigProviderBean;
+
+@ExtendWith(WeldJunit5Extension.class)
+public class StaticListServiceDiscoveryProgrammaticApiCDITest {
+
+    Stork stork;
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(TestConfigProviderBean.class,
+            StaticListServiceDiscoveryProviderLoader.class);
+
+    @Inject
+    TestConfigProviderBean config;
+
+    @BeforeEach
+    void setUp() {
+        config.clear();
+        stork = StorkTestUtils.getNewStorkInstance();
+        stork
+                .defineIfAbsent("first-service", ServiceDefinition.of(
+                        new StaticConfiguration()
+                                .withAddressList("localhost:8080, localhost:8081")))
+                .defineIfAbsent("second-service", ServiceDefinition.of(
+                        new StaticConfiguration().withAddressList("localhost:8082")
+                                .withSecure("true")))
+                .defineIfAbsent("third-service", ServiceDefinition.of(
+                        new StaticConfiguration().withAddressList("localhost:8083")))
+                .defineIfAbsent("secured-service", ServiceDefinition.of(
+                        new StaticConfiguration().withAddressList("localhost:443, localhost")))
+                .defineIfAbsent("shuffle-service", ServiceDefinition.of(
+                        new StaticConfiguration()
+                                .withAddressList("localhost:8080, localhost:8081").withShuffle("true")));
+    }
+
+    @Test
+    void testSecureDetection() {
+        List<ServiceInstance> instances = stork.getService("secured-service").getInstances().await()
+                .atMost(Duration.ofSeconds(5));
+
+        assertThat(instances).hasSize(2);
+        assertThat(instances.get(0).isSecure()).isTrue();
+        assertThat(instances.get(1).isSecure()).isFalse();
+
+        instances = stork.getService("second-service").getInstances().await().atMost(Duration.ofSeconds(5));
+        assertThat(instances).hasSize(1);
+        assertThat(instances.get(0).isSecure()).isTrue();
+    }
+
+    @Test
+    void shouldGetAllServiceInstances() {
+        List<ServiceInstance> serviceInstances = stork.getService("first-service")
+                .getInstances()
+                .await().atMost(Duration.ofSeconds(5));
+
+        assertThat(serviceInstances).hasSize(2);
+
+        List<String> list = serviceInstances.stream().map(si -> si.getHost() + ":" + si.getPort()).collect(Collectors.toList());
+        assertThat(list).containsExactly("localhost:8080", "localhost:8081");
+
+        assertThat(serviceInstances.stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("localhost",
+                "localhost");
+        assertThat(serviceInstances.stream().map(ServiceInstance::getPort)).containsExactly(8080, 8081);
+        assertThat(serviceInstances.stream().map(ServiceInstance::isSecure)).allSatisfy(b -> assertThat(b).isFalse());
+    }
+
+    @Test
+    void shouldGetAllServiceInstancesWithShuffle() {
+        List<ServiceInstance> serviceInstances = stork.getService("shuffle-service")
+                .getInstances()
+                .await().atMost(Duration.ofSeconds(5));
+
+        assertThat(serviceInstances).hasSize(2);
+
+        List<String> list = serviceInstances.stream().map(si -> si.getHost() + ":" + si.getPort()).collect(Collectors.toList());
+        assertThat(list).containsExactlyInAnyOrder("localhost:8080", "localhost:8081");
+
+        assertThat(serviceInstances.stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("localhost",
+                "localhost");
+        assertThat(serviceInstances.stream().map(ServiceInstance::getPort)).containsExactlyInAnyOrder(8080,
+                8081);
+        assertThat(serviceInstances.stream().map(ServiceInstance::isSecure)).allSatisfy(b -> assertThat(b).isFalse());
+    }
+
+    @Test
+    void shouldFailOnMissingService() {
+        assertThatThrownBy(() -> stork.getService("missing")).isInstanceOf(NoSuchServiceDefinitionException.class);
+        assertThat(stork.getServiceOptional("missing")).isEmpty();
+    }
+
+    @Test
+    void shouldFailOnInvalidFormat() {
+        assertThatThrownBy(() -> stork.defineIfAbsent("broken-service", ServiceDefinition.of(
+                new StaticConfiguration()
+                        .withAddressList("localhost:8080, localhost:8081, , ")))).isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("Address not parseable");
+    }
+
+}

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye.stork</groupId>
         <artifactId>stork-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-utils/revapi.json
+++ b/test-utils/revapi.json
@@ -27,92 +27,51 @@
     "differences" : [
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.test.EmptyServicesConfiguration",
-        "new": "class io.smallrye.stork.test.EmptyServicesConfiguration",
-        "interface": "io.smallrye.stork.api.config.ServiceDiscoveryConfig",
-        "justification": "The name of the implemented interface has changed."
-
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.test.EmptyServicesServiceDiscoveryProviderLoader",
+        "new": "class io.smallrye.stork.test.EmptyServicesServiceDiscoveryProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "the loaders are now also exposed as CDI beans"
       },
       {
         "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.test.EmptyServicesServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ServiceDiscoveryConfig===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "new": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.test.EmptyServicesServiceDiscoveryProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ConfigWithType===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
-
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.test.TestLoadBalancer1ProviderLoader",
+        "new": "class io.smallrye.stork.test.TestLoadBalancer1ProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "the loaders are now also exposed as CDI beans"
       },
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.test.TestLb1Configuration",
-        "new": "class io.smallrye.stork.test.TestLb1Configuration",
-        "interface": "io.smallrye.stork.api.config.LoadBalancerConfig",
-        "justification": "The name of the implemented interface has changed."
-
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.test.TestLoadBalancer2ProviderLoader",
+        "new": "class io.smallrye.stork.test.TestLoadBalancer2ProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "the loaders are now also exposed as CDI beans"
       },
       {
         "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.test.TestLb2Configuration",
-        "new": "class io.smallrye.stork.test.TestLb2Configuration",
-        "interface": "io.smallrye.stork.api.config.LoadBalancerConfig",
-        "justification": "The name of the implemented interface has changed."
-
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.test.TestServiceDiscovery1ProviderLoader",
+        "new": "class io.smallrye.stork.test.TestServiceDiscovery1ProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "the loaders are now also exposed as CDI beans"
       },
       {
         "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.test.TestLoadBalancer1ProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.LoadBalancerConfig===, io.smallrye.stork.api.ServiceDiscovery)",
-        "new": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.test.TestLoadBalancer1ProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.ConfigWithType===, io.smallrye.stork.api.ServiceDiscovery)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
-
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.test.TestServiceDiscovery2ProviderLoader",
+        "new": "class io.smallrye.stork.test.TestServiceDiscovery2ProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "the loaders are now also exposed as CDI beans"
       },
       {
         "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.test.TestLoadBalancer2ProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.LoadBalancerConfig===, io.smallrye.stork.api.ServiceDiscovery)",
-        "new": "parameter io.smallrye.stork.api.LoadBalancer io.smallrye.stork.test.TestLoadBalancer2ProviderLoader::createLoadBalancer(===io.smallrye.stork.api.config.ConfigWithType===, io.smallrye.stork.api.ServiceDiscovery)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
-
-      },
-      {
-        "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.test.TestSd1Configuration",
-        "new": "class io.smallrye.stork.test.TestSd1Configuration",
-        "interface": "io.smallrye.stork.api.config.ServiceDiscoveryConfig",
-        "justification": "The name of the implemented interface has changed."
-
-      },
-      {
-        "ignore": true,
-        "code": "java.class.noLongerImplementsInterface",
-        "old": "class io.smallrye.stork.test.TestSd2Configuration",
-        "new": "class io.smallrye.stork.test.TestSd2Configuration",
-        "interface": "io.smallrye.stork.api.config.ServiceDiscoveryConfig",
-        "justification": "The name of the implemented interface has changed."
-
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.test.TestServiceDiscovery1ProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ServiceDiscoveryConfig===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "new": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.test.TestServiceDiscovery1ProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ConfigWithType===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
-
-      },
-      {
-        "ignore": true,
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.test.TestServiceDiscovery2ProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ServiceDiscoveryConfig===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "new": "parameter io.smallrye.stork.api.ServiceDiscovery io.smallrye.stork.test.TestServiceDiscovery2ProviderLoader::createServiceDiscovery(===io.smallrye.stork.api.config.ConfigWithType===, java.lang.String, io.smallrye.stork.api.config.ServiceConfig, io.smallrye.stork.spi.StorkInfrastructure)",
-        "parameterIndex": "0",
-        "justification": "The name of the parameter type has changed."
+        "code": "java.annotation.added",
+        "old": "class io.smallrye.stork.test.TestServiceRegistrarProviderLoader",
+        "new": "class io.smallrye.stork.test.TestServiceRegistrarProviderLoader",
+        "annotation": "@jakarta.enterprise.context.ApplicationScoped",
+        "justification": "The loaders are now also exposed as CDI beans"
       }
     ]
   }

--- a/test-utils/src/main/java/io/smallrye/stork/test/TestConfigProviderBean.java
+++ b/test-utils/src/main/java/io/smallrye/stork/test/TestConfigProviderBean.java
@@ -6,38 +6,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 import io.smallrye.stork.api.config.ConfigWithType;
 import io.smallrye.stork.api.config.ServiceConfig;
 import io.smallrye.stork.api.config.ServiceRegistrarConfig;
 import io.smallrye.stork.spi.config.ConfigProvider;
 
 /**
- * Stork config provider for tests, allows easily configuring stuff programmatically
+ * Stork config provider for tests, allows easily configuring stuff programmatically.
+ * Unlike {@link TestConfigProvider}, this variant is a CDI bean.
  */
-public class TestConfigProvider implements ConfigProvider {
-    private static final List<ServiceConfig> configs = new ArrayList<>();
-    private static final List<ServiceRegistrarConfig> registrarConfigs = new ArrayList<>();
+@ApplicationScoped
+public class TestConfigProviderBean implements ConfigProvider {
+    private final List<ServiceConfig> configs = new ArrayList<>();
+    private final List<ServiceRegistrarConfig> registrarConfigs = new ArrayList<>();
 
-    private static int priority = Integer.MAX_VALUE - 1;
+    private int priority = Integer.MAX_VALUE;
 
-    public static void setPriority(int priority) {
-        TestConfigProvider.priority = priority;
+    public void setPriority(int priority) {
+        this.priority = priority;
     }
 
-    public static int getPriority() {
-        return priority;
-    }
-
-    @Deprecated
-    public static void addServiceConfig(String name, String loadBalancer, String serviceDiscovery,
-            Map<String, String> loadBalancerParams, Map<String, String> serviceDiscoveryParams, boolean secure) {
-        if (secure) {
-            serviceDiscoveryParams.put("secure", "true");
-        }
-        addServiceConfig(name, loadBalancer, serviceDiscovery, loadBalancerParams, serviceDiscoveryParams);
-    }
-
-    public static void addServiceConfig(String name, String loadBalancer, String serviceDiscovery,
+    public void addServiceConfig(String name, String loadBalancer, String serviceDiscovery,
             Map<String, String> loadBalancerParams, Map<String, String> serviceDiscoveryParams) {
         configs.add(new ServiceConfig() {
             @Override
@@ -77,7 +68,7 @@ public class TestConfigProvider implements ConfigProvider {
         });
     }
 
-    public static void addServiceRegistrarConfig(String registrarName, String registrarType, Map<String, String> parameters) {
+    public void addServiceRegistrarConfig(String registrarName, String registrarType, Map<String, String> parameters) {
         registrarConfigs.add(new ServiceRegistrarConfig() {
             @Override
             public String name() {
@@ -96,7 +87,7 @@ public class TestConfigProvider implements ConfigProvider {
         });
     }
 
-    public static void clear() {
+    public void clear() {
         configs.clear();
         registrarConfigs.clear();
     }


### PR DESCRIPTION

- Bump project version to 2.x
- Switch to the Jakarta API
- Allows instantiating service discovery provider, load balancer provider and service register provider as CDI beans 


_TODO:_

* [x] switch the provided providers to CDI
* [x] document the new approach to implementing providers, indicating that the previous approach still works
* [x] add a parameter to avoid the SPI registration (explicit opt-in to keep the compatibility)
* [x] update various dependencies to their Jakarta version