### PR TITLE
The config-generator must now depend on jakarta.enterprise.cdi-api

### DIFF
--- a/config-generator/pom.xml
+++ b/config-generator/pom.xml
@@ -30,5 +30,9 @@
             <artifactId>auto-service</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/32111
