### PR TITLE
Adding new property `port-name` in K8s to select a port by name

### DIFF
--- a/service-discovery/kubernetes/revapi.json
+++ b/service-discovery/kubernetes/revapi.json
@@ -25,7 +25,17 @@
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
     "differences" : [
-
+      {
+        "ignore": true,
+        "code": "java.annotation.attributeValueChanged",
+        "old": "class io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProvider",
+        "new": "class io.smallrye.stork.servicediscovery.kubernetes.KubernetesServiceDiscoveryProvider",
+        "annotationType": "io.smallrye.stork.api.config.ServiceDiscoveryAttributes",
+        "attribute": "value",
+        "oldValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"k8s-host\", description = \"The Kubernetes API host.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"k8s-namespace\", description = \"The namespace of the service. Use all to discover all namespaces.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"application\", description = \"The Kubernetes application Id; if not defined Stork service name will be used.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"refresh-period\", description = \"Service discovery cache refresh period.\", defaultValue = \"5M\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether the connection with the service should be encrypted with TLS.\")}",
+        "newValue": "{@io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"k8s-host\", description = \"The Kubernetes API host.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"k8s-namespace\", description = \"The namespace of the service. Use all to discover all namespaces.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"application\", description = \"The Kubernetes application Id; if not defined Stork service name will be used.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"port-name\", description = \"The Kubernetes application port name. If not defined, when exposing multiple ports, Stork will use the first one.\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"refresh-period\", description = \"Service discovery cache refresh period.\", defaultValue = \"5M\"), @io.smallrye.stork.api.config.ServiceDiscoveryAttribute(name = \"secure\", description = \"Whether the connection with the service should be encrypted with TLS.\")}",
+        "justification": "Added the 'port-name' attribute. Should not impact users."
+      }
     ]
   }
 }, {

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryProvider.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryProvider.java
@@ -18,6 +18,7 @@ import io.vertx.core.Vertx;
 @ServiceDiscoveryAttribute(name = "k8s-host", description = "The Kubernetes API host.")
 @ServiceDiscoveryAttribute(name = "k8s-namespace", description = "The namespace of the service. Use all to discover all namespaces.")
 @ServiceDiscoveryAttribute(name = "application", description = "The Kubernetes application Id; if not defined Stork service name will be used.")
+@ServiceDiscoveryAttribute(name = "port-name", description = "The Kubernetes application port name. If not defined, when exposing multiple ports, Stork will use the first one.")
 @ServiceDiscoveryAttribute(name = "refresh-period", description = "Service discovery cache refresh period.", defaultValue = CachingServiceDiscovery.DEFAULT_REFRESH_INTERVAL)
 @ServiceDiscoveryAttribute(name = "secure", description = "Whether the connection with the service should be encrypted with TLS.")
 @ApplicationScoped


### PR DESCRIPTION
This is especially necessary when having endpoints that expose multiple ports.  At the moment, when having multiple ports, Stork does not select any and uses port 80 which is problematic when the application does not use this port. 

Relates https://github.com/quarkusio/quarkus/issues/33131