### PR TITLE
Enable Kubernetes tests beacuse no reason to disable them

### DIFF
--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryCDITest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryCDITest.java
@@ -57,7 +57,6 @@ import io.smallrye.stork.test.TestConfigProviderBean;
 @DisabledOnOs(OS.WINDOWS)
 @ExtendWith(WeldJunit5Extension.class)
 @EnableKubernetesMockClient(crud = true)
-@Disabled("flaky test - see https://github.com/smallrye/smallrye-stork/issues/667")
 public class KubernetesServiceDiscoveryCDITest {
 
     @WeldSetup

--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
@@ -50,7 +50,6 @@ import io.smallrye.stork.test.TestConfigProvider;
 
 @DisabledOnOs(OS.WINDOWS)
 @EnableKubernetesMockClient(crud = true)
-@Disabled("flaky test - see https://github.com/smallrye/smallrye-stork/issues/667")
 public class KubernetesServiceDiscoveryTest {
 
     KubernetesClient client;


### PR DESCRIPTION
Fix #667 