### PR TITLE
Bump Vert.x to version 4.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <version.mutiny>2.5.3</version.mutiny>
         <version.smallrye-config>3.4.4</version.smallrye-config>
 
-        <vertx.version>4.4.1</vertx.version>
-        <version.vertx-mutiny-bindings>3.7.2</version.vertx-mutiny-bindings>
+        <vertx.version>4.5.1</vertx.version>
+        <version.vertx-mutiny-bindings>3.8.0</version.vertx-mutiny-bindings>
         <!-- override the testcontainers version with the newest one -->
         <version.testcontainers>1.19.3</version.testcontainers>
 


### PR DESCRIPTION
Also bump the Vert.x Mutiny bindings to version 3.8.0
