### PR TITLE
deprecate java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
     strategy:
       matrix:
         java: [
-          { 'version': '11', 'opts': '-Drevapi.skip' },
           { 'version': '17', 'opts': 'javadoc:javadoc' },
           { 'version': '20', 'opts': 'javadoc:javadoc' },
           { 'version': '21', 'opts': '-Drevapi.skip' }
@@ -54,7 +53,6 @@ jobs:
     strategy:
       matrix:
         java: [
-          { 'version': '11', 'opts': '' },
           { 'version': '17', 'opts': '' },
           { 'version': '20', 'opts': '' },
           { 'version': '21', 'opts': '' }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: maven release ${{steps.metadata.outputs.current-version}}


### PR DESCRIPTION
Use java 17 as base. 
Fixes #858 