### PR TITLE
Clear the in memory address backend on shutdown

### DIFF
--- a/core/src/main/java/io/smallrye/stork/Stork.java
+++ b/core/src/main/java/io/smallrye/stork/Stork.java
@@ -38,6 +38,7 @@ import io.smallrye.stork.spi.config.SimpleServiceConfig;
 import io.smallrye.stork.spi.internal.LoadBalancerLoader;
 import io.smallrye.stork.spi.internal.ServiceDiscoveryLoader;
 import io.smallrye.stork.spi.internal.ServiceRegistrarLoader;
+import io.smallrye.stork.utils.InMemoryAddressesBackend;
 
 /**
  * The entrypoint for SmallRye Stork.
@@ -274,7 +275,16 @@ public final class Stork implements StorkServiceRegistry {
      * Closes the stork instance.
      */
     public static void shutdown() {
-        REFERENCE.set(null);
+        var previous = REFERENCE.getAndSet(null);
+        if (previous != null) {
+            previous.clear();
+        }
+        InMemoryAddressesBackend.clearAll();
+    }
+
+    private void clear() {
+        services.clear();
+        serviceRegistrars.clear();
     }
 
     /**


### PR DESCRIPTION
This avoids leaking service instances when stork is re-initialized multiple times in a row (like during Quarkus continuous testing)
