### PR TITLE
Unable retries in k8s client and add test

### DIFF
--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
@@ -83,6 +83,7 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
 
         Config k8sConfig = new ConfigBuilder(base)
                 .withMasterUrl(masterUrl)
+                .withRequestRetryBackoffLimit(0) //TODO: expose this in the config
                 .withNamespace(namespace).build();
         this.client = new KubernetesClientBuilder().withConfig(k8sConfig).build();
         this.vertx = vertx;

--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
@@ -553,6 +553,83 @@ public class KubernetesServiceDiscoveryTest {
 
     }
 
+    /**
+     * Verifies that the cluster is reached when the cache is invalidated. No retries.
+     *  The cache is only reset when the call is success but this doesn't trigger multiple calls because retries are not enabled.
+     *
+     * <p>
+     * This test ensures that the system does not enter a loop of cluster calls when the cluster fails,
+     * and that it behaves correctly when the cluster state changes.
+     * </p>
+     */
+    @Test
+    void shouldCallTheClusterWhenCacheInvalidated() throws InterruptedException {
+        String serviceName = "svc";
+
+        //Recording k8s cluster calls and build the response with the (previous registered) endpoints
+        AtomicInteger serverHit = new AtomicInteger(0);
+        server.expect().get().withPath("/api/v1/namespaces/test/endpoints?fieldSelector=metadata.name%3Dsvc")
+                .andReply(500, r -> {
+                    serverHit.incrementAndGet();
+                    return "Internal Server Error";
+                }).always();
+
+        TestConfigProvider.addServiceConfig(serviceName, null, "kubernetes", null,
+                null, Map.of("k8s-host", k8sMasterUrl, "k8s-namespace", defaultNamespace, "refresh-period", "3"), null);
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        Service service = stork.getService(serviceName);
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        KubernetesServiceDiscovery serviceDiscovery = (KubernetesServiceDiscovery) service.getServiceDiscovery();
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(1);
+
+        //We trigger an event in the cluster just to invalidate cache
+        registerKubernetesResources(serviceName, defaultNamespace, "10.96.96.231", "10.96.96.232",
+                        "10.96.96.233");
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(2);
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        // Since the previous call failed, the cache wasn't reset and we reach the cluster this time incremeting the serverHit to 3.
+        assertThat(serverHit.get()).isEqualTo(3);
+
+        //We trigger an event in the cluster just to invalidate cache
+        registerKubernetesResources("svc2", defaultNamespace, "10.96.96.234", "10.96.96.235",
+                "10.96.96.236");
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(4);
+
+    }
+
     @Test
     void shouldFetchInstancesFromTheClusterWhenCacheIsInvalidated() throws InterruptedException {
 


### PR DESCRIPTION
Fixes #1021 
This solution addresses the issue of unnecessary retries triggered by the default Kubernetes client configuration. The core change is to disable automatic retries, ensuring that the cluster is only contacted when necessary.

Additionally, a test has been added to validate that the cluster is contacted only when the cache is invalidated. The cache is invalidated only when the instance retrieval is successful. If an error occurs during instance retrieval, the cache will not be reset, as resetting it would lead to potential inconsistencies. This behavior is expected and correct because we want to avoid resetting the cache on failure to prevent inconsistent states.

With this solution, the system avoids creating a loop of requests to the Kubernetes cluster and ensures it is only queried when the user calls service.getInstances() with an invalidated cache.

This is a draft because I still need certainly to expose the retries config.

cc @cescoffier @balif