### PR TITLE
Expose cache invalidation

### DIFF
--- a/core/src/test/java/io/smallrye/stork/impl/CachingServiceDiscoveryRefreshTest.java
+++ b/core/src/test/java/io/smallrye/stork/impl/CachingServiceDiscoveryRefreshTest.java
@@ -2,8 +2,10 @@ package io.smallrye.stork.impl;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,9 +15,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import io.smallrye.mutiny.Uni;
@@ -78,6 +82,137 @@ class CachingServiceDiscoveryRefreshTest {
 
             assertThat(servicesList == originalList).isTrue();
         }
+        executor.shutdown();
 
     }
+
+    @Test
+    @Timeout(10)
+    void shouldInvalidateCacheAndTriggerRefreshAgain() throws InterruptedException {
+        AtomicInteger refreshCount = new AtomicInteger(0);
+
+        CachingServiceDiscovery discovery = new CachingServiceDiscovery("1M") {
+            @Override
+            public Uni<List<ServiceInstance>> fetchNewServiceInstances(List<ServiceInstance> previousInstances) {
+                refreshCount.incrementAndGet();
+                return Uni.createFrom().item(List.of(
+                        new DefaultServiceInstance(1, "localhost", 8406, Optional.empty(), false),
+                        new DefaultServiceInstance(1, "localhost", 8407, Optional.empty(), false)));
+            }
+        };
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        discovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        // first call --> should call fetchNewInstances
+        assertThat(instances.get()).hasSize(2);
+        assertThat(refreshCount.get()).isEqualTo(1);
+
+        instances.set(null);
+
+        // Second call, no explicit validation happen --> should NOT call fetchNewInstances
+        discovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).hasSize(2);
+        assertThat(refreshCount.get()).isEqualTo(1);
+
+        instances.set(null);
+
+        // Explicit invalidation
+        discovery.invalidate();
+
+        // New call --> should NOT call fetchNewInstances
+        discovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).hasSize(2);
+        assertThat(refreshCount.get()).isEqualTo(2);
+    }
+
+    @RepeatedTest(4)
+    @Timeout(20)
+    void shouldCacheAndShareResultAcrossConsumers() throws InterruptedException {
+        int amountOfGets = 300;
+
+        List<List<ServiceInstance>> results = Collections.synchronizedList(new ArrayList<>());
+
+        AtomicInteger refreshCount = new AtomicInteger(0);
+        CountDownLatch awaitFinish = new CountDownLatch(amountOfGets);
+
+        ExecutorService executor = Executors.newFixedThreadPool(amountOfGets);
+
+        CachingServiceDiscovery discovery = new CachingServiceDiscovery("1M") {
+            @Override
+            public Uni<List<ServiceInstance>> fetchNewServiceInstances(List<ServiceInstance> previousInstances) {
+                refreshCount.incrementAndGet();
+                return Uni.createFrom().emitter(e -> {
+                    List<ServiceInstance> results = asList(
+                            new DefaultServiceInstance(1, "localhost", 8406, Optional.empty(), false),
+                            new DefaultServiceInstance(2, "localhost", 8407, Optional.empty(), false));
+                    vertx.setTimer(2000, ignored -> e.complete(results));
+                });
+            }
+        };
+        for (int i = 0; i < amountOfGets; i++) {
+            executor.execute(() -> {
+                discovery.getServiceInstances()
+                        .subscribe().with(instances -> {
+                            results.add(instances);
+                            awaitFinish.countDown();
+                        });
+            });
+
+        }
+        assertThat(awaitFinish.await(10, TimeUnit.SECONDS)).isTrue();
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(refreshCount::get, Matchers.equalTo(1));
+
+        assertThat(results).hasSize(amountOfGets);
+
+        List<ServiceInstance> beforeList = null;
+        for (List<ServiceInstance> servicesList : results) {
+            assertThat(servicesList).hasSize(2);
+
+            // verify it's the exact same list that is returned:
+            if (beforeList == null) {
+                beforeList = servicesList;
+            }
+
+            assertThat(servicesList == beforeList).isTrue();
+        }
+
+        discovery.invalidate();
+
+        AtomicReference<List<ServiceInstance>> afterList = new AtomicReference<>();
+
+        discovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances", th))
+                .subscribe().with(afterList::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> afterList.get() != null);
+
+        assertThat(afterList.get()).hasSize(2);
+        assertThat(afterList.get()).isNotSameAs(beforeList);
+
+        executor.shutdown();
+
+    }
+
 }

--- a/docs/docs/service-discovery/overview.md
+++ b/docs/docs/service-discovery/overview.md
@@ -9,4 +9,22 @@ It supports out of the box some service discovery such as Kubernetes or Consul b
 Stork allows services to communicate with each other without requiring hardcoded addresses, making it an ideal solution for microservices deployments.
 SmallRye Stork brings this capability to clients for Quarkus applications but it's vendor agnostic so you easily use it with other solutions and even in standalone mode.
 
+
+## Service discovery caching overview
+
+Stork provides a built-in caching mechanism for service discovery results.
+By default, each service discovery implementation may repeatedly contact its backend (e.g., Consul, Kubernetes, Eureka) to retrieve the current list of service instances.
+Since these lookups can be expensive or frequent, Stork allows service discovery providers to cache the retrieved instances for a configurable period of time.
+
+* Cached results are reused for subsequent lookups, avoiding unnecessary backend calls.
+* The cache is automatically refreshed after the configured `refresh-period`.
+* If a refresh fails, Stork keeps serving the previously retrieved list of instances until a new successful refresh occurs.
+
+In addition to the time-based refresh mechanism, Stork also exposes an **cache invalidation API** .
+This API can be used to explicitly clear the cached results, forcing the next lookup to perform a new service discovery call.
+This is especially useful when the service discovery backend supports event-based notifications (for example, Consul blocking queries), allowing the cache to be invalidated as soon as a change is detected.
+
+> For more details about how to enable caching in a custom service discovery implementation, see the [Caching the service instances](custom-service-discovery.md#caching-the-service-instances) section.
+
+
 You can explore the different implementations and learn how to create your own in the following sections.

--- a/docs/snippets/examples/CustomExpirationCachedAcmeServiceDiscovery.java
+++ b/docs/snippets/examples/CustomExpirationCachedAcmeServiceDiscovery.java
@@ -36,7 +36,7 @@ public class CustomExpirationCachedAcmeServiceDiscovery extends CachingServiceDi
         return uni.memoize().until(() -> invalidated.get());
     }
 
-    //command-based cache invalidation: user triggers the action to invalidate the cache.
+    @Override
     public void invalidate() {
         invalidated.set(true);
     }

--- a/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulRegisteringOptions.java
+++ b/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulRegisteringOptions.java
@@ -1,0 +1,6 @@
+package io.smallrye.stork.servicediscovery.consul;
+
+import java.util.List;
+
+public record ConsulRegisteringOptions(String serviceName, int port, List<String> tags, List<String> addresses) {
+}

--- a/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryCDITest.java
+++ b/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryCDITest.java
@@ -1,24 +1,10 @@
 package io.smallrye.stork.servicediscovery.consul;
 
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_ID;
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_NODE;
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_NODE_ADDRESS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.awaitility.Awaitility.await;
-
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 
-import org.assertj.core.util.Maps;
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldJunit5Extension;
 import org.jboss.weld.junit5.WeldSetup;
@@ -33,16 +19,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import io.smallrye.stork.Stork;
-import io.smallrye.stork.api.Metadata;
-import io.smallrye.stork.api.Service;
-import io.smallrye.stork.api.ServiceInstance;
-import io.smallrye.stork.impl.ConsulMetadataKey;
 import io.smallrye.stork.test.StorkTestUtils;
 import io.smallrye.stork.test.TestConfigProviderBean;
 import io.vertx.core.Vertx;
 import io.vertx.ext.consul.ConsulClient;
 import io.vertx.ext.consul.ConsulClientOptions;
-import io.vertx.ext.consul.ServiceOptions;
 
 @Testcontainers
 @ExtendWith(WeldJunit5Extension.class)
@@ -63,67 +44,31 @@ public class ConsulServiceDiscoveryCDITest {
     Stork stork;
     int consulPort;
     ConsulClient client;
-    long consulId;
 
     @BeforeEach
     void setUp() {
         config.clear();
         consulPort = consul.getMappedPort(8500);
-        consulId = 0L;
         client = ConsulClient.create(Vertx.vertx(),
                 new ConsulClientOptions().setHost("localhost").setPort(consulPort));
     }
 
     @Test
     void shouldNotFetchWhenRefreshPeriodNotReached() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 minutes
+        //Given a service discovery config for `my-service`
         String serviceName = "my-service";
         config.addServiceConfig("my-service", null, "consul",
                 null,
                 Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5M"));
         stork = StorkTestUtils.getNewStorkInstance();
         List<String> tags = List.of("primary");
-        registerService(serviceName, 8406, tags, "example.com");
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(10))
-                .until(() -> instances.get() != null);
-
-        deregisterServiceInstances(instances.get());
-
-        List<String> sTags = List.of("secondary");
-        registerService(serviceName, 8506, sTags, "another.example.com");
-
-        // when the consul service discovery is called before the end of refreshing period
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork returns the instances from the cache
-        assertThat(instances.get()).hasSize(1);
-        ServiceInstance serviceInstance = instances.get().get(0);
-        assertThat(serviceInstance.getHost()).isEqualTo("example.com");
-        assertThat(serviceInstance.getPort()).isEqualTo(8406);
-        assertThat(serviceInstance.getLabels()).containsKey("primary");
-        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) serviceInstance.getMetadata();
-        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
-                META_CONSUL_SERVICE_NODE_ADDRESS);
+        ConsulServiceDiscoveryTestUtils.shouldNotFetchWhenRefreshPeriodNotReached(stork, client, serviceName, tags);
 
     }
 
     @Test
     void shouldRefetchWhenRefreshPeriodReached() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-service";
         config.addServiceConfig("my-service", null, "consul",
                 null,
@@ -131,114 +76,47 @@ public class ConsulServiceDiscoveryCDITest {
         stork = StorkTestUtils.getNewStorkInstance();
         //Given a service `my-service` registered in consul
         List<String> tags = List.of("primary");
-        Map<String, String> metadata = Maps.newHashMap("meta", "metadata for my-service");
-        registerService(serviceName, 8406, tags, "example.com");
+        ConsulServiceDiscoveryTestUtils.shouldRefetchWhenRefreshPeriodReached(stork, client, serviceName, tags);
+    }
 
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+    @Test
+    void shouldRefetchWhenCacheInvalidated() throws InterruptedException {
+        //Given a service discovery config for `my-service`
+        String serviceName = "my-service";
+        config.addServiceConfig("my-service", null, "consul",
+                null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"));
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("example.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-
-        deregisterServiceInstances(instances.get());
-
-        //the service settings change in consul
-        List<String> sTags = List.of("secondary");
-        registerService(serviceName, 8506, sTags, "another.example.com");
-
-        // let's wait until the new services are populated to Stork (from Consul)
-        await().atMost(Duration.ofSeconds(7))
-                .until(() -> service.getServiceDiscovery().getServiceInstances().await().indefinitely().get(0).getHost()
-                        .equals("another.example.com"));
-
-        instances.set(null);
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork gets the instances from consul
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("another.example.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8506);
-        assertThat(instances.get().get(0).getLabels()).containsKey("secondary");
-        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) instances.get().get(0).getMetadata();
-        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
-                META_CONSUL_SERVICE_NODE_ADDRESS);
+        List<String> tags = List.of("primary");
+        ConsulServiceDiscoveryTestUtils.shouldRefetchWhenCacheInvalidated(client, stork, serviceName, tags);
     }
 
     @Test
     void shouldDiscoverServiceWithSpecificName() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-consul-service";
         config.addServiceConfig("my-consul-service", null, "consul", null,
                 Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5",
                         "application", "my-consul-service"));
         stork = StorkTestUtils.getNewStorkInstance();
-        //Given a service `my-service` registered in consul
-        registerService("my-consul-service", 8406, null, "consul.com");
-        registerService("another-service", 8606, null, "another.example.com");
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("consul.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-        assertThat(instances.get().get(0).isSecure()).isFalse();
+        ConsulServiceDiscoveryTestUtils.shouldDiscoverServiceWithSpecificName(client, stork, serviceName);
     }
 
     @Test
     void shouldHandleTheSecureAttribute() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-consul-service";
         config.addServiceConfig("my-consul-service", null, "consul",
                 null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5",
                         "application", "my-consul-service", "secure", "true"));
         stork = StorkTestUtils.getNewStorkInstance();
-        //Given a service `my-service` registered in consul
-        registerService("my-consul-service", 8406, null, "consul.com");
-        registerService("another-service", 8606, null, "another.example.com");
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("consul.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-        assertThat(instances.get().get(0).isSecure()).isTrue();
+        ConsulServiceDiscoveryTestUtils.shouldHandleTheSecureAttribute(client, stork, serviceName);
     }
 
     @Test
     void shouldPreserveIdsOnRefetch() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-service";
         config.addServiceConfig("my-service", null, "consul",
                 null,
@@ -246,96 +124,19 @@ public class ConsulServiceDiscoveryCDITest {
         stork = StorkTestUtils.getNewStorkInstance();
         //Given a service `my-service` registered in consul
         List<String> tags = List.of("primary");
-        registerService(serviceName, 8406, tags, "example.com");
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        ServiceInstance serviceInstance = instances.get().get(0);
-        assertThat(serviceInstance.getHost()).isEqualTo("example.com");
-        assertThat(serviceInstance.getPort()).isEqualTo(8406);
-
-        long serviceId = serviceInstance.getId();
-
-        deregisterServiceInstances(instances.get());
-
-        //the service settings change in consul
-        registerService(serviceName, 8406, tags, "example.com", "another.example.com");
-
-        // let's wait until the new services are populated to Stork (from Consul)
-        await().atMost(Duration.ofSeconds(10)).until(
-                () -> service.getServiceDiscovery().getServiceInstances().await().atMost(Duration.ofSeconds(5)).size() == 2);
-
-        instances.set(null);
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork gets the instances from consul
-        assertThat(instances.get()).hasSize(2);
-
-        Optional<ServiceInstance> exampleCom = instances.get().stream().filter(i -> i.getHost().equals("example.com"))
-                .findAny();
-        assertThat(exampleCom)
-                .isNotEmpty()
-                .hasValueSatisfying(instance -> assertThat(instance.getId()).isEqualTo(serviceId));
-
-        Optional<ServiceInstance> anotherExample = instances.get().stream()
-                .filter(i -> i.getHost().equals("another.example.com")).findAny();
-        assertThat(anotherExample).isNotEmpty()
-                .hasValueSatisfying(instance -> assertThat(instance.getId()).isNotEqualTo(serviceId));
+        ConsulServiceDiscoveryTestUtils.shouldPreserveIdsOnRefetch(client, stork, serviceName, tags);
     }
 
-    private void registerService(String serviceName, int port, List<String> tags,
-            String... addresses) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(addresses.length);
-        for (String address : addresses) {
-            client.registerService(
-                    new ServiceOptions().setId("" + (consulId++)).setName(serviceName).setTags(tags)
-                            .setAddress(address).setPort(port))
-                    .onComplete(result -> {
-                        if (result.failed()) {
-                            fail("Failed to register service in Consul", result.cause());
-                        }
-                        latch.countDown();
-                    });
-        }
-        if (!latch.await(5, TimeUnit.SECONDS)) {
-            fail("Failed to register service in consul in time");
-        }
-    }
-
-    private void deregisterServiceInstances(List<ServiceInstance> serviceInstances) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        List<String> consulIds = serviceInstances.stream().map(ServiceInstance::getMetadata)
-                .map(metadata -> metadata.getMetadata().get(META_CONSUL_SERVICE_ID))
-                .filter(consulId -> consulId instanceof String)
-                .map(consulId -> (String) consulId)
-                .collect(Collectors.toList());
-        for (String id : consulIds) {
-            client.deregisterService(id, res -> {
-                if (res.succeeded()) {
-                    latch.countDown();
-                } else {
-                    res.cause().printStackTrace();
-                }
-            });
-            if (!latch.await(5, TimeUnit.SECONDS)) {
-                fail("Failed to deregister service in consul in time");
-            }
-        }
+    @Test
+    void shouldDiscoverServiceWithoutAddress() throws InterruptedException {
+        //Given a service `my-consul-service` registered in consul and a refresh-period of 5 seconds
+        String serviceName = "my-consul-service";
+        config.addServiceConfig(serviceName, null, "consul", null,
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5",
+                        "application", "my-consul-service"),
+                null);
+        stork = StorkTestUtils.getNewStorkInstance();
+        ConsulServiceDiscoveryTestUtils.shouldDiscoverServiceWithoutAddress(client, stork, serviceName);
     }
 
 }

--- a/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryProgrammaticApiCDITest.java
+++ b/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryProgrammaticApiCDITest.java
@@ -1,24 +1,10 @@
 package io.smallrye.stork.servicediscovery.consul;
 
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_ID;
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_NODE;
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_NODE_ADDRESS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.awaitility.Awaitility.await;
-
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 
-import org.assertj.core.util.Maps;
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldJunit5Extension;
 import org.jboss.weld.junit5.WeldSetup;
@@ -33,17 +19,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import io.smallrye.stork.Stork;
-import io.smallrye.stork.api.Metadata;
-import io.smallrye.stork.api.Service;
 import io.smallrye.stork.api.ServiceDefinition;
-import io.smallrye.stork.api.ServiceInstance;
-import io.smallrye.stork.impl.ConsulMetadataKey;
 import io.smallrye.stork.test.StorkTestUtils;
 import io.smallrye.stork.test.TestConfigProviderBean;
 import io.vertx.core.Vertx;
 import io.vertx.ext.consul.ConsulClient;
 import io.vertx.ext.consul.ConsulClientOptions;
-import io.vertx.ext.consul.ServiceOptions;
 
 @Testcontainers
 @DisabledOnOs(OS.WINDOWS)
@@ -63,13 +44,11 @@ public class ConsulServiceDiscoveryProgrammaticApiCDITest {
     Stork stork;
     int consulPort;
     ConsulClient client;
-    long consulId;
 
     @BeforeEach
     void setUp() {
         config.clear();
         consulPort = consul.getMappedPort(8500);
-        consulId = 0L;
         client = ConsulClient.create(Vertx.vertx(),
                 new ConsulClientOptions().setHost("localhost").setPort(consulPort));
         stork = StorkTestUtils.getNewStorkInstance();
@@ -79,47 +58,14 @@ public class ConsulServiceDiscoveryProgrammaticApiCDITest {
     void shouldNotFetchWhenRefreshPeriodNotReached() throws InterruptedException {
         //Given a service `my-service` registered in consul and a refresh-period of 5 minutes
         String serviceName = "my-service";
+        config.addServiceConfig("my-service", null, "consul",
+                null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5M"));
 
-        ConsulConfiguration config = new ConsulConfiguration().withConsulHost("localhost")
-                .withConsulPort(String.valueOf(consulPort)).withRefreshPeriod("5M");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
+        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config.getConfigs().get(0).serviceDiscovery()));
 
         List<String> tags = List.of("primary");
-        registerService(serviceName, 8406, tags, "example.com");
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(10))
-                .until(() -> instances.get() != null);
-
-        deregisterServiceInstances(instances.get());
-
-        List<String> sTags = List.of("secondary");
-        registerService(serviceName, 8506, sTags, "another.example.com");
-
-        // when the consul service discovery is called before the end of refreshing period
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork returns the instances from the cache
-        assertThat(instances.get()).hasSize(1);
-        ServiceInstance serviceInstance = instances.get().get(0);
-        assertThat(serviceInstance.getHost()).isEqualTo("example.com");
-        assertThat(serviceInstance.getPort()).isEqualTo(8406);
-        assertThat(serviceInstance.getLabels()).containsKey("primary");
-        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) serviceInstance.getMetadata();
-        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
-                META_CONSUL_SERVICE_NODE_ADDRESS);
+        ConsulServiceDiscoveryTestUtils.shouldNotFetchWhenRefreshPeriodNotReached(stork, client, serviceName, tags);
 
     }
 
@@ -127,220 +73,81 @@ public class ConsulServiceDiscoveryProgrammaticApiCDITest {
     void shouldRefetchWhenRefreshPeriodReached() throws InterruptedException {
         //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
         String serviceName = "my-service";
-        ConsulConfiguration config = new ConsulConfiguration().withConsulHost("localhost")
-                .withConsulPort(String.valueOf(consulPort)).withRefreshPeriod("5");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
+        config.addServiceConfig("my-service", null, "consul",
+                null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"));
+
+        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config.getConfigs().get(0).serviceDiscovery()));
 
         //Given a service `my-service` registered in consul
         List<String> tags = List.of("primary");
-        Map<String, String> metadata = Maps.newHashMap("meta", "metadata for my-service");
-        registerService(serviceName, 8406, tags, "example.com");
+        ConsulServiceDiscoveryTestUtils.shouldRefetchWhenRefreshPeriodReached(stork, client, serviceName, tags);
+    }
 
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+    @Test
+    void shouldRefetchWhenCacheInvalidated() throws InterruptedException {
+        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        String serviceName = "my-service";
+        config.addServiceConfig("my-service", null, "consul",
+                null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"));
 
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
+        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config.getConfigs().get(0).serviceDiscovery()));
 
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("example.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-
-        deregisterServiceInstances(instances.get());
-
-        //the service settings change in consul
-        List<String> sTags = List.of("secondary");
-        registerService(serviceName, 8506, sTags, "another.example.com");
-
-        // let's wait until the new services are populated to Stork (from Consul)
-        await().atMost(Duration.ofSeconds(7))
-                .until(() -> service.getServiceDiscovery().getServiceInstances().await().indefinitely().get(0).getHost()
-                        .equals("another.example.com"));
-
-        instances.set(null);
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork gets the instances from consul
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("another.example.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8506);
-        assertThat(instances.get().get(0).getLabels()).containsKey("secondary");
-        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) instances.get().get(0).getMetadata();
-        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
-                META_CONSUL_SERVICE_NODE_ADDRESS);
+        List<String> tags = List.of("primary");
+        ConsulServiceDiscoveryTestUtils.shouldRefetchWhenCacheInvalidated(client, stork, serviceName, tags);
     }
 
     @Test
     void shouldDiscoverServiceWithSpecificName() throws InterruptedException {
         //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
         String serviceName = "my-consul-service";
-        ConsulConfiguration config = new ConsulConfiguration().withConsulHost("localhost")
-                .withConsulPort(String.valueOf(consulPort))
-                .withRefreshPeriod("5M").withApplication("my-consul-service");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
+        config.addServiceConfig("my-consul-service", null, "consul",
+                null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5M"));
 
-        //Given a service `my-service` registered in consul
-        registerService("my-consul-service", 8406, null, "consul.com");
-        registerService("another-service", 8606, null, "another.example.com");
+        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config.getConfigs().get(0).serviceDiscovery()));
 
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("consul.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-        assertThat(instances.get().get(0).isSecure()).isFalse();
+        ConsulServiceDiscoveryTestUtils.shouldDiscoverServiceWithSpecificName(client, stork, serviceName);
     }
 
     @Test
     void shouldHandleTheSecureAttribute() throws InterruptedException {
         //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
         String serviceName = "my-consul-service";
-        ConsulConfiguration config = new ConsulConfiguration().withConsulHost("localhost")
-                .withConsulPort(String.valueOf(consulPort))
-                .withRefreshPeriod("5M").withApplication("my-consul-service")
-                .withSecure("true");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
+        config.addServiceConfig("my-consul-service", null, "consul",
+                null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5M", "secure",
+                        "true"));
 
-        //Given a service `my-service` registered in consul
-        registerService("my-consul-service", 8406, null, "consul.com");
-        registerService("another-service", 8606, null, "another.example.com");
+        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config.getConfigs().get(0).serviceDiscovery()));
 
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("consul.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-        assertThat(instances.get().get(0).isSecure()).isTrue();
+        ConsulServiceDiscoveryTestUtils.shouldHandleTheSecureAttribute(client, stork, serviceName);
     }
 
     @Test
     void shouldPreserveIdsOnRefetch() throws InterruptedException {
         //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
         String serviceName = "my-service";
-        ConsulConfiguration config = new ConsulConfiguration().withConsulHost("localhost")
-                .withConsulPort(String.valueOf(consulPort))
-                .withRefreshPeriod("5");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
+        config.addServiceConfig("my-service", null, "consul",
+                null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"));
+
+        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config.getConfigs().get(0).serviceDiscovery()));
 
         List<String> tags = List.of("primary");
-        registerService(serviceName, 8406, tags, "example.com");
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        ServiceInstance serviceInstance = instances.get().get(0);
-        assertThat(serviceInstance.getHost()).isEqualTo("example.com");
-        assertThat(serviceInstance.getPort()).isEqualTo(8406);
-
-        long serviceId = serviceInstance.getId();
-
-        deregisterServiceInstances(instances.get());
-
-        //the service settings change in consul
-        registerService(serviceName, 8406, tags, "example.com", "another.example.com");
-
-        // let's wait until the new services are populated to Stork (from Consul)
-        await().atMost(Duration.ofSeconds(10)).until(
-                () -> service.getServiceDiscovery().getServiceInstances().await().atMost(Duration.ofSeconds(5)).size() == 2);
-
-        instances.set(null);
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork gets the instances from consul
-        assertThat(instances.get()).hasSize(2);
-
-        Optional<ServiceInstance> exampleCom = instances.get().stream().filter(i -> i.getHost().equals("example.com"))
-                .findAny();
-        assertThat(exampleCom)
-                .isNotEmpty()
-                .hasValueSatisfying(instance -> assertThat(instance.getId()).isEqualTo(serviceId));
-
-        Optional<ServiceInstance> anotherExample = instances.get().stream()
-                .filter(i -> i.getHost().equals("another.example.com")).findAny();
-        assertThat(anotherExample).isNotEmpty()
-                .hasValueSatisfying(instance -> assertThat(instance.getId()).isNotEqualTo(serviceId));
+        ConsulServiceDiscoveryTestUtils.shouldPreserveIdsOnRefetch(client, stork, serviceName, tags);
     }
 
-    private void registerService(String serviceName, int port, List<String> tags,
-            String... addresses) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(addresses.length);
-        for (String address : addresses) {
-            client.registerService(
-                    new ServiceOptions().setId("" + (consulId++)).setName(serviceName).setTags(tags)
-                            .setAddress(address).setPort(port))
-                    .onComplete(result -> {
-                        if (result.failed()) {
-                            fail("Failed to register service in Consul", result.cause());
-                        }
-                        latch.countDown();
-                    });
-        }
-        if (!latch.await(5, TimeUnit.SECONDS)) {
-            fail("Failed to register service in consul in time");
-        }
-    }
+    @Test
+    void shouldDiscoverServiceWithoutAddress() throws InterruptedException {
+        //Given a service `my-consul-service` registered in consul and a refresh-period of 5 seconds
+        String serviceName = "my-consul-service";
+        config.addServiceConfig("my-consul-service", null, "consul",
+                null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"));
 
-    private void deregisterServiceInstances(List<ServiceInstance> serviceInstances) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        List<String> consulIds = serviceInstances.stream().map(ServiceInstance::getMetadata)
-                .map(metadata -> metadata.getMetadata().get(META_CONSUL_SERVICE_ID))
-                .filter(consulId -> consulId instanceof String)
-                .map(consulId -> (String) consulId)
-                .collect(Collectors.toList());
-        for (String id : consulIds) {
-            client.deregisterService(id, res -> {
-                if (res.succeeded()) {
-                    latch.countDown();
-                } else {
-                    res.cause().printStackTrace();
-                }
-            });
-            if (!latch.await(5, TimeUnit.SECONDS)) {
-                fail("Failed to deregister service in consul in time");
-            }
-        }
+        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config.getConfigs().get(0).serviceDiscovery()));
+        ConsulServiceDiscoveryTestUtils.shouldDiscoverServiceWithoutAddress(client, stork, serviceName);
     }
-
 }

--- a/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryTest.java
+++ b/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryTest.java
@@ -1,23 +1,8 @@
 package io.smallrye.stork.servicediscovery.consul;
 
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_ID;
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_NODE;
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_NODE_ADDRESS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.awaitility.Awaitility.await;
-
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
-import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -28,16 +13,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import io.smallrye.stork.Stork;
-import io.smallrye.stork.api.Metadata;
-import io.smallrye.stork.api.Service;
-import io.smallrye.stork.api.ServiceInstance;
-import io.smallrye.stork.impl.ConsulMetadataKey;
 import io.smallrye.stork.test.StorkTestUtils;
 import io.smallrye.stork.test.TestConfigProvider;
 import io.vertx.core.Vertx;
 import io.vertx.ext.consul.ConsulClient;
 import io.vertx.ext.consul.ConsulClientOptions;
-import io.vertx.ext.consul.ServiceOptions;
 
 @Testcontainers
 @DisabledOnOs(OS.WINDOWS)
@@ -49,13 +29,11 @@ public class ConsulServiceDiscoveryTest {
     Stork stork;
     int consulPort;
     ConsulClient client;
-    long consulId;
 
     @BeforeEach
     void setUp() {
         TestConfigProvider.clear();
         consulPort = consul.getMappedPort(8500);
-        consulId = 0L;
         client = ConsulClient.create(Vertx.vertx(),
                 new ConsulClientOptions().setHost("localhost").setPort(consulPort));
     }
@@ -69,47 +47,13 @@ public class ConsulServiceDiscoveryTest {
                 null);
         stork = StorkTestUtils.getNewStorkInstance();
         List<String> tags = List.of("primary");
-        registerService(new ConsulServiceOptions(serviceName, 8406, tags, List.of("example.com")));
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(10))
-                .until(() -> instances.get() != null);
-
-        deregisterServiceInstances(instances.get());
-
-        List<String> sTags = List.of("secondary");
-        registerService(new ConsulServiceOptions(serviceName, 8506, sTags, List.of("another.example.com")));
-
-        // when the consul service discovery is called before the end of refreshing period
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork returns the instances from the cache
-        assertThat(instances.get()).hasSize(1);
-        ServiceInstance serviceInstance = instances.get().get(0);
-        assertThat(serviceInstance.getHost()).isEqualTo("example.com");
-        assertThat(serviceInstance.getPort()).isEqualTo(8406);
-        assertThat(serviceInstance.getLabels()).containsKey("primary");
-        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) serviceInstance.getMetadata();
-        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
-                META_CONSUL_SERVICE_NODE_ADDRESS);
+        ConsulServiceDiscoveryTestUtils.shouldNotFetchWhenRefreshPeriodNotReached(stork, client, serviceName, tags);
 
     }
 
     @Test
     void shouldRefetchWhenRefreshPeriodReached() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-service";
         TestConfigProvider.addServiceConfig("my-service", null, "consul", null,
                 null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
@@ -117,86 +61,37 @@ public class ConsulServiceDiscoveryTest {
         stork = StorkTestUtils.getNewStorkInstance();
         //Given a service `my-service` registered in consul
         List<String> tags = List.of("primary");
-        Map<String, String> metadata = Maps.newHashMap("meta", "metadata for my-service");
-        registerService(new ConsulServiceOptions(serviceName, 8406, tags, List.of("example.com")));
+        ConsulServiceDiscoveryTestUtils.shouldRefetchWhenRefreshPeriodReached(stork, client, serviceName, tags);
+    }
 
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+    @Test
+    void shouldRefetchWhenCacheInvalidated() throws InterruptedException {
+        //Given a service discovery config for `my-service`
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig("my-service", null, "consul", null,
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "60"),
+                null);
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("example.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-
-        deregisterServiceInstances(instances.get());
-
-        //the service settings change in consul
-        List<String> sTags = List.of("secondary");
-        registerService(new ConsulServiceOptions(serviceName, 8506, sTags, List.of("another.example.com")));
-
-        // let's wait until the new services are populated to Stork (from Consul)
-        await().atMost(Duration.ofSeconds(7))
-                .until(() -> service.getServiceDiscovery().getServiceInstances().await().indefinitely().get(0).getHost()
-                        .equals("another.example.com"));
-
-        instances.set(null);
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork gets the instances from consul
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("another.example.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8506);
-        assertThat(instances.get().get(0).getLabels()).containsKey("secondary");
-        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) instances.get().get(0).getMetadata();
-        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
-                META_CONSUL_SERVICE_NODE_ADDRESS);
+        List<String> tags = List.of("primary");
+        ConsulServiceDiscoveryTestUtils.shouldRefetchWhenCacheInvalidated(client, stork, serviceName, tags);
     }
 
     @Test
     void shouldDiscoverServiceWithSpecificName() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-consul-service";
         TestConfigProvider.addServiceConfig("my-consul-service", null, "consul", null,
                 null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5",
                         "application", "my-consul-service"),
                 null);
         stork = StorkTestUtils.getNewStorkInstance();
-        //Given a service `my-service` registered in consul
-        registerService(new ConsulServiceOptions("my-consul-service", 8406, null, List.of("consul.com")));
-        registerService(new ConsulServiceOptions("another-service", 8606, null, List.of("another.example.com")));
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("consul.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-        assertThat(instances.get().get(0).isSecure()).isFalse();
+        ConsulServiceDiscoveryTestUtils.shouldDiscoverServiceWithSpecificName(client, stork, serviceName);
     }
 
     @Test
     void shouldHandleTheSecureAttribute() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-consul-service";
         TestConfigProvider.addServiceConfig("my-consul-service", null, "consul", null,
                 null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5",
@@ -204,160 +99,31 @@ public class ConsulServiceDiscoveryTest {
                 null);
         stork = StorkTestUtils.getNewStorkInstance();
         //Given a service `my-service` registered in consul
-        registerService(new ConsulServiceOptions("my-consul-service", 8406, null, List.of("consul.com")));
-        registerService(new ConsulServiceOptions("another-service", 8606, null, List.of("another.example.com")));
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("consul.com");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-        assertThat(instances.get().get(0).isSecure()).isTrue();
+        ConsulServiceDiscoveryTestUtils.shouldHandleTheSecureAttribute(client, stork, serviceName);
     }
 
     @Test
     void shouldPreserveIdsOnRefetch() throws InterruptedException {
-        //Given a service `my-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-service";
         TestConfigProvider.addServiceConfig("my-service", null, "consul", null,
                 null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
                 null);
         stork = StorkTestUtils.getNewStorkInstance();
         List<String> tags = List.of("primary");
-        registerService(new ConsulServiceOptions(serviceName, 8406, tags, List.of("example.com")));
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        assertThat(instances.get()).hasSize(1);
-        ServiceInstance serviceInstance = instances.get().get(0);
-        assertThat(serviceInstance.getHost()).isEqualTo("example.com");
-        assertThat(serviceInstance.getPort()).isEqualTo(8406);
-
-        long serviceId = serviceInstance.getId();
-
-        deregisterServiceInstances(instances.get());
-
-        //the service settings change in consul
-        registerService(new ConsulServiceOptions(serviceName, 8406, tags, List.of("example.com", "another.example.com")));
-
-        // let's wait until the new services are populated to Stork (from Consul)
-        await().atMost(Duration.ofSeconds(10)).until(
-                () -> service.getServiceDiscovery().getServiceInstances().await().atMost(Duration.ofSeconds(5)).size() == 2);
-
-        instances.set(null);
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        //Then stork gets the instances from consul
-        assertThat(instances.get()).hasSize(2);
-
-        Optional<ServiceInstance> exampleCom = instances.get().stream().filter(i -> i.getHost().equals("example.com"))
-                .findAny();
-        assertThat(exampleCom)
-                .isNotEmpty()
-                .hasValueSatisfying(instance -> assertThat(instance.getId()).isEqualTo(serviceId));
-
-        Optional<ServiceInstance> anotherExample = instances.get().stream()
-                .filter(i -> i.getHost().equals("another.example.com")).findAny();
-        assertThat(anotherExample).isNotEmpty()
-                .hasValueSatisfying(instance -> assertThat(instance.getId()).isNotEqualTo(serviceId));
+        ConsulServiceDiscoveryTestUtils.shouldPreserveIdsOnRefetch(client, stork, serviceName, tags);
     }
 
     @Test
     void shouldDiscoverServiceWithoutAddress() throws InterruptedException {
-        //Given a service `my-consul-service` registered in consul and a refresh-period of 5 seconds
+        //Given a service discovery config for `my-service`
         String serviceName = "my-consul-service";
-        TestConfigProvider.addServiceConfig("my-consul-service", null, "consul", null,
+        TestConfigProvider.addServiceConfig(serviceName, null, "consul", null,
                 null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5",
                         "application", "my-consul-service"),
                 null);
         stork = StorkTestUtils.getNewStorkInstance();
-        registerService(new ConsulServiceOptions("my-consul-service", 8406, null, new ArrayList<>()));
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        // Then the service instance is found
-        assertThat(instances.get()).hasSize(1);
-        assertThat(instances.get().get(0).getHost()).isEqualTo("127.0.0.1");
-        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
-        assertThat(instances.get().get(0).isSecure()).isFalse();
-    }
-
-    public record ConsulServiceOptions(String serviceName, int port, List<String> tags, List<String> addresses) {
-    }
-
-    private void registerService(ConsulServiceOptions consulServiceOptions) throws InterruptedException {
-        if (consulServiceOptions.addresses().isEmpty()) {
-            consulServiceOptions.addresses.add("");
-        }
-        CountDownLatch latch = new CountDownLatch(consulServiceOptions.addresses().size());
-        for (String address : consulServiceOptions.addresses()) {
-            client.registerService(
-                    new ServiceOptions().setId("" + (consulId++)).setName(consulServiceOptions.serviceName())
-                            .setTags(consulServiceOptions.tags())
-                            .setAddress(address).setPort(consulServiceOptions.port()))
-                    .onComplete(result -> {
-                        if (result.failed()) {
-                            fail("Failed to register service in Consul", result.cause());
-                        }
-                        latch.countDown();
-                    });
-        }
-        if (!latch.await(5, TimeUnit.SECONDS)) {
-            fail("Failed to register service in consul in time");
-        }
-    }
-
-    private void deregisterServiceInstances(List<ServiceInstance> serviceInstances) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        List<String> consulIds = serviceInstances.stream().map(ServiceInstance::getMetadata)
-                .map(metadata -> metadata.getMetadata().get(META_CONSUL_SERVICE_ID))
-                .filter(consulId -> consulId instanceof String)
-                .map(consulId -> (String) consulId)
-                .collect(Collectors.toList());
-        for (String id : consulIds) {
-            client.deregisterService(id, res -> {
-                if (res.succeeded()) {
-                    latch.countDown();
-                } else {
-                    res.cause().printStackTrace();
-                }
-            });
-            if (!latch.await(5, TimeUnit.SECONDS)) {
-                fail("Failed to deregister service in consul in time");
-            }
-        }
+        ConsulServiceDiscoveryTestUtils.shouldDiscoverServiceWithoutAddress(client, stork, serviceName);
     }
 
 }

--- a/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryTestUtils.java
+++ b/service-discovery/consul/src/test/java/io/smallrye/stork/servicediscovery/consul/ConsulServiceDiscoveryTestUtils.java
@@ -1,0 +1,341 @@
+package io.smallrye.stork.servicediscovery.consul;
+
+import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_ID;
+import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_NODE;
+import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_NODE_ADDRESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.Metadata;
+import io.smallrye.stork.api.Service;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.impl.ConsulMetadataKey;
+import io.vertx.ext.consul.ConsulClient;
+import io.vertx.ext.consul.ServiceOptions;
+
+public class ConsulServiceDiscoveryTestUtils {
+
+    private static long consulId = 0L;
+
+    public static void shouldNotFetchWhenRefreshPeriodNotReached(Stork stork, ConsulClient client, String serviceName,
+            List<String> tags)
+            throws InterruptedException {
+
+        registerService(client, new ConsulRegisteringOptions(serviceName, 8406, tags, List.of("example.com")));
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        // call stork service discovery and gather service instances in the cache
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> instances.get() != null);
+
+        deregisterServiceInstances(client, instances.get());
+
+        List<String> sTags = List.of("secondary");
+        registerService(client,
+                new ConsulRegisteringOptions(serviceName, 8506, sTags, List.of("another.example.com")));
+
+        // when the consul service discovery is called before the end of refreshing period
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        //Then stork returns the instances from the cache
+        assertThat(instances.get()).hasSize(1);
+        ServiceInstance serviceInstance = instances.get().get(0);
+        assertThat(serviceInstance.getHost()).isEqualTo("example.com");
+        assertThat(serviceInstance.getPort()).isEqualTo(8406);
+        assertThat(serviceInstance.getLabels()).containsKey("primary");
+        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) serviceInstance.getMetadata();
+        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
+                META_CONSUL_SERVICE_NODE_ADDRESS);
+    }
+
+    public static void shouldRefetchWhenRefreshPeriodReached(Stork stork, ConsulClient client, String serviceName,
+            List<String> tags) throws InterruptedException {
+        registerService(client, new ConsulRegisteringOptions(serviceName, 8406, tags, List.of("example.com")));
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        // call stork service discovery and gather service instances in the cache
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).hasSize(1);
+        assertThat(instances.get().get(0).getHost()).isEqualTo("example.com");
+        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
+
+        deregisterServiceInstances(client, instances.get());
+
+        //the service settings change in consul
+        List<String> sTags = List.of("secondary");
+        registerService(client, new ConsulRegisteringOptions(serviceName, 8506, sTags, List.of("another.example.com")));
+
+        // let's wait until the new services are populated to Stork (from Consul)
+        await().atMost(Duration.ofSeconds(7))
+                .until(() -> service.getServiceDiscovery().getServiceInstances().await().indefinitely().get(0).getHost()
+                        .equals("another.example.com"));
+
+        instances.set(null);
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        //Then stork gets the instances from consul
+        assertThat(instances.get()).hasSize(1);
+        assertThat(instances.get().get(0).getHost()).isEqualTo("another.example.com");
+        assertThat(instances.get().get(0).getPort()).isEqualTo(8506);
+        assertThat(instances.get().get(0).getLabels()).containsKey("secondary");
+        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) instances.get().get(0).getMetadata();
+        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
+                META_CONSUL_SERVICE_NODE_ADDRESS);
+    }
+
+    public static void shouldRefetchWhenCacheInvalidated(ConsulClient client, Stork stork, String serviceName,
+            List<String> tags) throws InterruptedException {
+        registerService(client, new ConsulRegisteringOptions(serviceName, 8406, tags, List.of("example.com")));
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        // call stork service discovery and gather service instances in the cache
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).hasSize(1);
+        assertThat(instances.get().get(0).getHost()).isEqualTo("example.com");
+        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
+
+        deregisterServiceInstances(client, instances.get());
+
+        //the service settings change in consul
+        List<String> sTags = List.of("secondary");
+        registerService(client,
+                new ConsulRegisteringOptions(serviceName, 8506, sTags, List.of("another.example.com")));
+
+        // the refresh period is not yet finish (60s), the service instance are populated from cache
+        await().atMost(Duration.ofSeconds(7))
+                .until(() -> service.getServiceDiscovery().getServiceInstances().await().indefinitely().get(0).getHost()
+                        .equals("example.com"));
+
+        //Force cache invalidation
+        ConsulServiceDiscovery consulServiceDiscovery = (ConsulServiceDiscovery) service.getServiceDiscovery();
+        consulServiceDiscovery.invalidate();
+
+        instances.set(null);
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        //Then stork gets the instances from consul
+        assertThat(instances.get()).hasSize(1);
+        assertThat(instances.get().get(0).getHost()).isEqualTo("another.example.com");
+        assertThat(instances.get().get(0).getPort()).isEqualTo(8506);
+        assertThat(instances.get().get(0).getLabels()).containsKey("secondary");
+        Metadata<ConsulMetadataKey> consulMetadata = (Metadata<ConsulMetadataKey>) instances.get().get(0).getMetadata();
+        assertThat(consulMetadata.getMetadata()).containsKeys(META_CONSUL_SERVICE_ID, META_CONSUL_SERVICE_NODE,
+                META_CONSUL_SERVICE_NODE_ADDRESS);
+    }
+
+    public static void shouldDiscoverServiceWithSpecificName(ConsulClient client, Stork stork, String serviceName)
+            throws InterruptedException {
+        //Given a service `my-service` registered in consul
+        registerService(client, new ConsulRegisteringOptions("my-consul-service", 8406, null, List.of("consul.com")));
+        registerService(client, new ConsulRegisteringOptions("another-service", 8606, null, List.of("another.example.com")));
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        // call stork service discovery and gather service instances in the cache
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(7))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).hasSize(1);
+        assertThat(instances.get().get(0).getHost()).isEqualTo("consul.com");
+        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
+        assertThat(instances.get().get(0).isSecure()).isFalse();
+    }
+
+    public static void shouldHandleTheSecureAttribute(ConsulClient client, Stork stork, String serviceName)
+            throws InterruptedException {
+        registerService(client, new ConsulRegisteringOptions("my-consul-service", 8406, null, List.of("consul.com")));
+        registerService(client,
+                new ConsulRegisteringOptions("another-service", 8606, null, List.of("another.example.com")));
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        // call stork service discovery and gather service instances in the cache
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).hasSize(1);
+        assertThat(instances.get().get(0).getHost()).isEqualTo("consul.com");
+        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
+        assertThat(instances.get().get(0).isSecure()).isTrue();
+    }
+
+    public static void shouldPreserveIdsOnRefetch(ConsulClient client, Stork stork, String serviceName, List<String> tags)
+            throws InterruptedException {
+        registerService(client, new ConsulRegisteringOptions(serviceName, 8406, tags, List.of("example.com")));
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        // call stork service discovery and gather service instances in the cache
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).hasSize(1);
+        ServiceInstance serviceInstance = instances.get().get(0);
+        assertThat(serviceInstance.getHost()).isEqualTo("example.com");
+        assertThat(serviceInstance.getPort()).isEqualTo(8406);
+
+        long serviceId = serviceInstance.getId();
+
+        deregisterServiceInstances(client, instances.get());
+
+        //the service settings change in consul
+        registerService(client,
+                new ConsulRegisteringOptions(serviceName, 8406, tags, List.of("example.com", "another.example.com")));
+
+        // let's wait until the new services are populated to Stork (from Consul)
+        await().atMost(Duration.ofSeconds(10)).until(
+                () -> service.getServiceDiscovery().getServiceInstances().await().atMost(Duration.ofSeconds(5)).size() == 2);
+
+        instances.set(null);
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        //Then stork gets the instances from consul
+        assertThat(instances.get()).hasSize(2);
+
+        Optional<ServiceInstance> exampleCom = instances.get().stream().filter(i -> i.getHost().equals("example.com"))
+                .findAny();
+        assertThat(exampleCom)
+                .isNotEmpty()
+                .hasValueSatisfying(instance -> assertThat(instance.getId()).isEqualTo(serviceId));
+
+        Optional<ServiceInstance> anotherExample = instances.get().stream()
+                .filter(i -> i.getHost().equals("another.example.com")).findAny();
+        assertThat(anotherExample).isNotEmpty()
+                .hasValueSatisfying(instance -> assertThat(instance.getId()).isNotEqualTo(serviceId));
+    }
+
+    public static void shouldDiscoverServiceWithoutAddress(ConsulClient client, Stork stork, String serviceName)
+            throws InterruptedException {
+        registerService(client, new ConsulRegisteringOptions(serviceName, 8406, null, new ArrayList<>()));
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        // call stork service discovery and gather service instances in the cache
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        // Then the service instance is found
+        assertThat(instances.get()).hasSize(1);
+        assertThat(instances.get().get(0).getHost()).isEqualTo("127.0.0.1");
+        assertThat(instances.get().get(0).getPort()).isEqualTo(8406);
+        assertThat(instances.get().get(0).isSecure()).isFalse();
+    }
+
+    public static void registerService(ConsulClient client, ConsulRegisteringOptions ConsulRegisteringOptions)
+            throws InterruptedException {
+        if (ConsulRegisteringOptions.addresses().isEmpty()) {
+            ConsulRegisteringOptions.addresses().add("");
+        }
+        CountDownLatch latch = new CountDownLatch(ConsulRegisteringOptions.addresses().size());
+        for (String address : ConsulRegisteringOptions.addresses()) {
+            client.registerService(
+                    new ServiceOptions().setId("" + (consulId++)).setName(ConsulRegisteringOptions.serviceName())
+                            .setTags(ConsulRegisteringOptions.tags())
+                            .setAddress(address).setPort(ConsulRegisteringOptions.port()))
+                    .onComplete(result -> {
+                        if (result.failed()) {
+                            fail("Failed to register service in Consul", result.cause());
+                        }
+                        latch.countDown();
+                    });
+        }
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            fail("Failed to register service in consul in time");
+        }
+    }
+
+    public static void deregisterServiceInstances(ConsulClient client, List<ServiceInstance> serviceInstances)
+            throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> consulIds = serviceInstances.stream().map(ServiceInstance::getMetadata)
+                .map(metadata -> metadata.getMetadata().get(META_CONSUL_SERVICE_ID))
+                .filter(consulId -> consulId instanceof String)
+                .map(consulId -> (String) consulId)
+                .collect(Collectors.toList());
+        for (String id : consulIds) {
+            client.deregisterService(id, res -> {
+                if (res.succeeded()) {
+                    latch.countDown();
+                } else {
+                    res.cause().printStackTrace();
+                }
+            });
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                fail("Failed to deregister service in consul in time");
+            }
+        }
+    }
+}

--- a/service-discovery/dns/src/test/java/io/smallrye/stork/servicediscovery/dns/DnsServiceDiscoveryCDITest.java
+++ b/service-discovery/dns/src/test/java/io/smallrye/stork/servicediscovery/dns/DnsServiceDiscoveryCDITest.java
@@ -1,16 +1,13 @@
 package io.smallrye.stork.servicediscovery.dns;
 
+import static io.smallrye.stork.servicediscovery.dns.DnsServiceDiscoveryTestUtils.getDnsIp;
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.notNullValue;
 
-import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.inject.Inject;
 
@@ -36,17 +33,11 @@ import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Ports;
 
 import io.smallrye.stork.Stork;
-import io.smallrye.stork.api.Service;
-import io.smallrye.stork.api.ServiceDefinition;
-import io.smallrye.stork.api.ServiceInstance;
 import io.smallrye.stork.test.StorkTestUtils;
 import io.smallrye.stork.test.TestConfigProviderBean;
-import io.smallrye.stork.utils.HostAndPort;
-import io.smallrye.stork.utils.StorkAddressUtils;
 import io.vertx.core.Vertx;
 import io.vertx.ext.consul.ConsulClient;
 import io.vertx.ext.consul.ConsulClientOptions;
-import io.vertx.ext.consul.ServiceOptions;
 
 @Testcontainers
 @DisabledOnOs(OS.WINDOWS)
@@ -84,7 +75,6 @@ public class DnsServiceDiscoveryCDITest {
     int consulPort;
     int dnsPort;
     ConsulClient client;
-    long consulId;
 
     @BeforeEach
     void setUp() {
@@ -118,27 +108,23 @@ public class DnsServiceDiscoveryCDITest {
         stork = StorkTestUtils.getNewStorkInstance();
 
         // without waiting we're sometimes in a state where container is not ready yet for second test
-        await().atMost(10, TimeUnit.SECONDS).until(this::clientCanTalkToConsul);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> DnsServiceDiscoveryTestUtils.clientCanTalkToConsul(client));
     }
 
     @AfterEach
     void cleanUp() throws InterruptedException {
-        deregisterServiceInstances();
+        DnsServiceDiscoveryTestUtils.deregisterServiceInstances(client, log, registeredConsulServices);
     }
 
     @Test
     void shouldGetInstancesForMavenOrg() {
+        config.addServiceConfig("maven", null, "dns", null,
+                null, Map.of("hostname", "maven.org", "record-type", "A", "port", "8392", "refresh-period", "5M"),
+                null);
         String serviceName = "maven";
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        DnsConfiguration config = new DnsConfiguration().withHostname("maven.org").withRecordType("A")
-                .withPort("8392");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
-
-        List<ServiceInstance> serviceInstances = getServiceInstances(serviceName, 20);
-        assertThat(serviceInstances).isNotEmpty();
-        for (ServiceInstance serviceInstance : serviceInstances) {
-            assertThat(serviceInstance.getPort()).isEqualTo(8392);
-        }
+        DnsServiceDiscoveryTestUtils.shouldGetInstancesForMavenOrg(stork, serviceName);
 
     }
 
@@ -147,16 +133,15 @@ public class DnsServiceDiscoveryCDITest {
         //Given a service `my-service` registered in consul (available via DNS) and a refresh-period of 5 minutes
         String serviceName = "my-service";
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname("my-service.service.dc1.consul").withRefreshPeriod("5M")
-                .withPort("8111");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
+        config.addServiceConfig("my-service", null, "dns", null,
+                null,
+                Map.of("hostname", "my-service.service.dc1.consul", "dns-servers", getDnsIp(consul) + ":" + dnsPort, "port",
+                        "8111", "refresh-period", "5M"),
+                null);
 
-        registerService(serviceName, "127.0.0.5:8406");
+        stork = StorkTestUtils.getNewStorkInstance();
+        DnsServiceDiscoveryTestUtils.shouldGetServiceInstanceIdsFromDns(stork, client, serviceName, registeredConsulServices);
 
-        List<ServiceInstance> instances = getServiceInstances(serviceName, 20);
-        assertThat(instances).isNotEmpty();
-        assertThat(instances.get(0).getHost()).isEqualTo("127.0.0.5");
     }
 
     @Test
@@ -164,40 +149,42 @@ public class DnsServiceDiscoveryCDITest {
         //Given a service `my-service` registered in consul (available via DNS) and a refresh-period of 5 minutes
         String serviceName = "my-service";
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname("my-service.service.dc1.consul").withRefreshPeriod("5M")
-                .withPort("8111")
-                .withResolveSrv("false");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
+        config.addServiceConfig("my-service", null, "dns", null,
+                null,
+                Map.of("hostname", "my-service.service.dc1.consul", "dns-servers", getDnsIp(consul) + ":" + dnsPort, "port",
+                        "8111", "resolve-srv", "false", "refresh-period", "5M"),
+                null);
 
-        registerService(serviceName, "7f000005.addr.dc1.consul:8406");
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        List<ServiceInstance> instances = getServiceInstances(serviceName, 20);
-        assertThat(instances).isNotEmpty();
-        assertThat(instances.get(0).getHost()).isEqualTo("7f000005.addr.dc1.consul");
+        DnsServiceDiscoveryTestUtils.shouldGetServiceInstanceIdsFromDnsWithoutResolving(stork, client, serviceName,
+                registeredConsulServices);
     }
 
     @Test
     void shouldFailWithoutPortForA() throws InterruptedException {
-        //Given a service `my-service-2` registered in consul and a refresh-period of 5 minutes
-        String serviceName = "my-service-3";
+        //Given a service `my-service-3` registered in consul and a refresh-period of 5 minutes
+        config.addServiceConfig("my-service", null, "dns", null,
+                null,
+                Map.of("hostname", "my-service.service.dc1.consul", "dns-servers", getDnsIp(consul) + ":" + dnsPort,
+                        "record-type",
+                        "A"),
+                null);
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname(serviceName + ".service.dc1.consul")
-                .withRecordType("A");
-        assertThatThrownBy(() -> stork.defineIfAbsent(serviceName, ServiceDefinition.of(config)))
+        assertThatThrownBy(() -> StorkTestUtils.getNewStorkInstance())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void shouldFailWithoutPortForAAAA() throws InterruptedException {
-        //Given a service `my-service-2` registered in consul and a refresh-period of 5 minutes
-        String serviceName = "my-service-3";
+        config.addServiceConfig("my-service", null, "dns", null,
+                null,
+                Map.of("hostname", "my-service.service.dc1.consul", "dns-servers", getDnsIp(consul) + ":" + dnsPort,
+                        "record-type",
+                        "AAAA"),
+                null);
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname(serviceName + ".service.dc1.consul")
-                .withRecordType("AAAA");
-        assertThatThrownBy(() -> stork.defineIfAbsent(serviceName, ServiceDefinition.of(config)))
+        assertThatThrownBy(() -> StorkTestUtils.getNewStorkInstance())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -206,50 +193,32 @@ public class DnsServiceDiscoveryCDITest {
         //Given a service `my-service-2` registered in consul and a refresh-period of 5 minutes
         String serviceName = "my-service-3";
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname(serviceName + ".service.dc1.consul")
-                .withRecordType("A")
-                .withPort("8111");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
-        // 8333 port won't be included in A record, so the result should have 8111
-        registerService(serviceName, "127.0.0.5:8333", "127.0.0.6");
+        config.addServiceConfig(serviceName, null, "dns", null,
+                null,
+                Map.of("hostname", "my-service-3.service.dc1.consul", "dns-servers", getDnsIp(consul) + ":" + dnsPort, "port",
+                        "8111", "record-type", "A"),
+                null);
 
-        List<ServiceInstance> serviceInstances = getServiceInstances(serviceName, 5);
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        assertThat(serviceInstances).hasSize(2);
-
-        ServiceInstance five = serviceInstances.stream().filter(i -> i.getHost().endsWith("5")).findFirst().get();
-        ServiceInstance six = serviceInstances.stream().filter(i -> i.getHost().endsWith("6")).findFirst().get();
-
-        assertThat(five.getPort()).isEqualTo(8111);
-        assertThat(six.getPort()).isEqualTo(8111);
+        DnsServiceDiscoveryTestUtils.shouldFetchA(stork, client, serviceName, registeredConsulServices);
     }
 
     @Test
     void shouldFetchSRVWithAValues() throws InterruptedException {
-        //Given a service `my-service-2` registered in consul and a refresh-period of 5 minutes
+        //Given a service `my-service-x` registered in consul and a refresh-period of 5 minutes
         String serviceName = "my-service-x";
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname(serviceName + ".service.dc1.consul");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
-        // 8333 port won't be included in A record, so the result should have 8111
-        int port1 = 8333;
-        String ip1 = "127.1.1.23";
-        int port2 = 8334;
-        String ip2 = "127.1.1.24";
-        registerService(serviceName, "[" + ip1 + "]:" + port1, "[" + ip2 + "]:" + port2);
+        config.addServiceConfig(serviceName, null, "dns", null,
+                null,
+                Map.of("hostname", "my-service-x.service.dc1.consul", "dns-servers", getDnsIp(consul) + ":" + dnsPort),
+                null);
 
-        List<ServiceInstance> serviceInstances = getServiceInstances(serviceName, 5);
-        assertThat(serviceInstances).hasSize(2);
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        ServiceInstance first = serviceInstances.stream().filter(i -> i.getHost().equals(ip1)).findFirst().get();
-        ServiceInstance second = serviceInstances.stream().filter(i -> i.getHost().equals(ip2)).findFirst().get();
+        DnsServiceDiscoveryTestUtils.shouldFetchSRVWithAValues(stork, client, serviceName,
+                registeredConsulServices);
 
-        assertThat(first.getPort()).isEqualTo(port1);
-        assertThat(second.getPort()).isEqualTo(port2);
-        assertThat(first.getMetadata().getMetadata().get(DnsMetadataKey.DNS_WEIGHT)).isNotNull();
-        assertThat(second.getPort()).isEqualTo(port2);
     }
 
     @Test
@@ -257,33 +226,15 @@ public class DnsServiceDiscoveryCDITest {
         //Given a service `my-service-2` registered in consul and a refresh-period of 5 minutes
         String serviceName = "my-service-x";
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname(serviceName + ".service.dc1.consul");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
-        // 8333 port won't be included in A record, so the result should have 8111
-        int port1 = 8333;
-        String ip1 = "2001:db8:85a3:0:0:8a2e:370:7334";
-        int port2 = 8334;
-        String ip2 = "2001:db8:85a3:0:0:8a2e:370:7335";
-        registerService(serviceName, "[" + ip1 + "]:" + port1, "[" + ip2 + "]:" + port2);
+        config.addServiceConfig(serviceName, null, "dns", null,
+                null,
+                Map.of("hostname", "my-service-x.service.dc1.consul", "dns-servers", getDnsIp(consul) + ":" + dnsPort),
+                null);
 
-        Service service = stork.getService(serviceName);
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        List<ServiceInstance> serviceInstances = instances.get();
-        assertThat(serviceInstances).hasSize(2);
-
-        ServiceInstance first = serviceInstances.stream().filter(i -> i.getHost().equals(ip1)).findFirst().get();
-        ServiceInstance second = serviceInstances.stream().filter(i -> i.getHost().equals(ip2)).findFirst().get();
-
-        assertThat(first.getPort()).isEqualTo(port1);
-        assertThat(second.getPort()).isEqualTo(port2);
+        DnsServiceDiscoveryTestUtils.shouldFetchSRVWithAAAAValues(stork, client, serviceName,
+                registeredConsulServices);
     }
 
     @Test
@@ -291,26 +242,16 @@ public class DnsServiceDiscoveryCDITest {
         //Given a service `my-service-2` registered in consul and a refresh-period of 5 minutes
         String serviceName = "my-service-3";
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname(serviceName + ".service.dc1.consul")
-                .withRecordType("AAAA")
-                .withPort("8111");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
-        // 8333 port won't be included in A record, so the result should have 8111
-        int port1 = 8333;
-        String ip1 = "2001:db8:85a3:0:0:8a2e:370:7334";
-        String ip2 = "2001:db8:85a3:0:0:8a2e:370:7335";
-        registerService(serviceName, "[" + ip1 + "]:" + port1, ip2);
+        config.addServiceConfig(serviceName, null, "dns", null,
+                null,
+                Map.of("hostname", serviceName + ".service.dc1.consul", "record-type", "AAAA", "port", "8111", "dns-servers",
+                        getDnsIp(consul) + ":" + dnsPort, "refresh-period", "5M"),
+                null);
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        List<ServiceInstance> serviceInstances = getServiceInstances(serviceName, 5);
+        DnsServiceDiscoveryTestUtils.shouldFetchAAAA(stork, client, serviceName,
+                registeredConsulServices);
 
-        assertThat(serviceInstances).hasSize(2);
-
-        ServiceInstance first = serviceInstances.stream().filter(i -> i.getHost().equals(ip1)).findFirst().get();
-        ServiceInstance second = serviceInstances.stream().filter(i -> i.getHost().equals(ip2)).findFirst().get();
-
-        assertThat(first.getPort()).isEqualTo(8111);
-        assertThat(second.getPort()).isEqualTo(8111);
     }
 
     @Test
@@ -318,131 +259,32 @@ public class DnsServiceDiscoveryCDITest {
         //Given a service `my-service-2` registered in consul and a refresh-period of 5 minutes
         String serviceName = "my-service-2";
 
-        DnsConfiguration config = new DnsConfiguration().withDnsServers(getDnsIp() + ":" + dnsPort)
-                .withHostname("my-service-2.service.dc1.consul").withRefreshPeriod("5s")
-                .withRecordType("SRV");
-        stork.defineIfAbsent(serviceName, ServiceDefinition.of(config));
-        registerService(serviceName, "127.0.0.5:8406");
+        config.addServiceConfig(serviceName, null, "dns", null,
+                null,
+                Map.of("hostname", "my-service-2.service.dc1.consul", "record-type", "SRV", "dns-servers",
+                        getDnsIp(consul) + ":" + dnsPort, "refresh-period", "5s"),
+                null);
+        stork = StorkTestUtils.getNewStorkInstance();
 
-        List<ServiceInstance> serviceInstances = getServiceInstances(serviceName, 20);
-
-        assertThat(serviceInstances).isNotEmpty();
-        ServiceInstance firstInstance = serviceInstances.get(0);
-        assertThat(firstInstance.getHost()).isEqualTo("127.0.0.5");
-        long firstInstanceId = firstInstance.getId();
-
-        deregisterServiceInstances();
-        //the service settings change in consul
-        registerService(serviceName, "127.0.0.6:8407", "127.0.0.5:8406");
-
-        Service service = stork.getService(serviceName);
-        // let's wait until the new services are populated to Stork (from DNS)
-        await().atMost(Duration.ofSeconds(7))
-                .until(() -> service.getServiceDiscovery().getServiceInstances().await().indefinitely().size() == 2);
-
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(5))
-                .until(() -> instances.get() != null);
-
-        serviceInstances = instances.get();
-        assertThat(serviceInstances.stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder(
-                "127.0.0.5", "127.0.0.6");
-        long firstInstanceIdAfterRefetch = serviceInstances.stream()
-                .filter(instance -> instance.getHost().equals("127.0.0.5"))
-                .findFirst()
-                .orElseThrow()
-                .getId();
-        assertThat(firstInstanceId).isEqualTo(firstInstanceIdAfterRefetch);
-
-        ServiceInstance five = serviceInstances.stream().filter(i -> i.getHost().endsWith("5")).findFirst().get();
-        ServiceInstance six = serviceInstances.stream().filter(i -> i.getHost().endsWith("6")).findFirst().get();
-
-        assertThat(five.getPort()).isEqualTo(8406);
-        assertThat(six.getPort()).isEqualTo(8407);
+        DnsServiceDiscoveryTestUtils.shouldRefetchWhenRefreshPeriodReached(stork, log, client, serviceName,
+                registeredConsulServices);
     }
 
-    private String getDnsIp() {
-        @SuppressWarnings("deprecation")
-        String dnsIp = consul.getContainerIpAddress();
+    @Test
+    void shouldRefetchWhenCacheInvalidated() throws InterruptedException {
+        //Given a service `my-service-2` registered in consul and a refresh-period of 5 minutes
+        String serviceName = "my-service-2";
 
-        if ("localhost".equals(dnsIp)) {
-            dnsIp = "127.0.0.1";
-        }
-        return dnsIp;
+        config.addServiceConfig(serviceName, null, "dns", null,
+                null,
+                Map.of("hostname", "my-service-2.service.dc1.consul", "record-type", "SRV", "dns-servers",
+                        getDnsIp(consul) + ":" + dnsPort, "refresh-period", "5M"),
+                null);
+        stork = StorkTestUtils.getNewStorkInstance();
+
+        DnsServiceDiscoveryTestUtils.shouldRefetchWhenCacheInvalidated(stork, log, client, serviceName,
+                registeredConsulServices);
+
     }
 
-    private List<ServiceInstance> getServiceInstances(String serviceName, int seconds) {
-        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
-
-        Service service = stork.getService(serviceName);
-        // call stork service discovery and gather service instances in the cache
-        service.getServiceDiscovery().getServiceInstances()
-                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
-                .subscribe().with(instances::set);
-
-        await().atMost(Duration.ofSeconds(seconds))
-                .until(() -> instances.get() != null);
-        return instances.get();
-    }
-
-    private void registerService(String application,
-            String... addresses) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(addresses.length);
-        Set<String> consulServiceIds = new HashSet<>();
-        for (String addressString : addresses) {
-            HostAndPort address = StorkAddressUtils.parseToHostAndPort(addressString, 0, "");
-            String consulServiceId = "" + (consulId++);
-            client.registerService(
-                    new ServiceOptions().setId(consulServiceId).setName(application)
-                            .setAddress(address.host).setPort(address.port))
-                    .onComplete(result -> {
-                        if (result.failed()) {
-                            fail("Failed to register service in Consul " + address, result.cause());
-                        } else {
-                            consulServiceIds.add(consulServiceId);
-                            latch.countDown();
-                        }
-                    });
-        }
-        if (!latch.await(10, TimeUnit.SECONDS)) {
-            fail("Failed to register service in consul in time");
-        }
-        registeredConsulServices.addAll(consulServiceIds);
-    }
-
-    private void deregisterServiceInstances() throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(registeredConsulServices.size());
-        for (String id : registeredConsulServices) {
-
-            log.info("unregistering service {}", id);
-            client.deregisterService(id, res -> {
-                if (res.succeeded()) {
-                    log.info("unregistered service {}", id);
-                    latch.countDown();
-                } else {
-                    fail("Failed to deregister service in consul", res.cause());
-                }
-            });
-        }
-        if (!latch.await(10, TimeUnit.SECONDS)) {
-            fail("Failed to deregister service in consul in time");
-        }
-        registeredConsulServices.clear();
-    }
-
-    private boolean clientCanTalkToConsul() {
-        var done = new CompletableFuture<>();
-        client.agentInfo().onFailure(done::completeExceptionally)
-                .onSuccess(done::complete);
-        try {
-            done.get();
-            return true;
-        } catch (Exception any) {
-            return false;
-        }
-    }
 }

--- a/service-discovery/dns/src/test/java/io/smallrye/stork/servicediscovery/dns/DnsServiceDiscoveryTestUtils.java
+++ b/service-discovery/dns/src/test/java/io/smallrye/stork/servicediscovery/dns/DnsServiceDiscoveryTestUtils.java
@@ -1,0 +1,315 @@
+package io.smallrye.stork.servicediscovery.dns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.testcontainers.containers.GenericContainer;
+
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.Service;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.utils.HostAndPort;
+import io.smallrye.stork.utils.StorkAddressUtils;
+import io.vertx.ext.consul.ConsulClient;
+import io.vertx.ext.consul.ServiceOptions;
+
+public class DnsServiceDiscoveryTestUtils {
+
+    private static long consulId = 0L;
+
+    public static void shouldGetInstancesForMavenOrg(Stork stork, String serviceName) {
+        List<ServiceInstance> serviceInstances = getServiceInstances(stork, serviceName, 20);
+        assertThat(serviceInstances).isNotEmpty();
+        for (ServiceInstance serviceInstance : serviceInstances) {
+            assertThat(serviceInstance.getPort()).isEqualTo(8392);
+        }
+    }
+
+    public static void shouldGetServiceInstanceIdsFromDns(Stork stork, ConsulClient client, String serviceName,
+            Set<String> registeredConsulServices) throws InterruptedException {
+        registerService(client, registeredConsulServices, serviceName, "127.0.0.5:8406");
+
+        List<ServiceInstance> instances = getServiceInstances(stork, serviceName, 20);
+        assertThat(instances).isNotEmpty();
+        assertThat(instances.get(0).getHost()).isEqualTo("127.0.0.5");
+    }
+
+    public static void shouldGetServiceInstanceIdsFromDnsWithoutResolving(Stork stork, ConsulClient client, String serviceName,
+            Set<String> registeredConsulServices) throws InterruptedException {
+        registerService(client, registeredConsulServices, serviceName, "7f000005.addr.dc1.consul:8406");
+
+        List<ServiceInstance> instances = getServiceInstances(stork, serviceName, 20);
+        assertThat(instances).isNotEmpty();
+        assertThat(instances.get(0).getHost()).isEqualTo("7f000005.addr.dc1.consul");
+    }
+
+    public static void shouldFetchA(Stork stork, ConsulClient client, String serviceName,
+            Set<String> registeredConsulServices) throws InterruptedException {
+        registerService(client, registeredConsulServices, serviceName, "127.0.0.5:8333", "127.0.0.6");
+
+        List<ServiceInstance> serviceInstances = getServiceInstances(stork, serviceName, 5);
+
+        assertThat(serviceInstances).hasSize(2);
+
+        ServiceInstance five = serviceInstances.stream().filter(i -> i.getHost().endsWith("5")).findFirst().get();
+        ServiceInstance six = serviceInstances.stream().filter(i -> i.getHost().endsWith("6")).findFirst().get();
+
+        assertThat(five.getPort()).isEqualTo(8111);
+        assertThat(six.getPort()).isEqualTo(8111);
+    }
+
+    public static void shouldFetchSRVWithAValues(Stork stork, ConsulClient client, String serviceName,
+            Set<String> registeredConsulServices) throws InterruptedException {
+        // 8333 port won't be included in A record, so the result should have 8111
+        int port1 = 8333;
+        String ip1 = "127.1.1.23";
+        int port2 = 8334;
+        String ip2 = "127.1.1.24";
+        registerService(client, registeredConsulServices, serviceName, "[" + ip1 + "]:" + port1, "[" + ip2 + "]:" + port2);
+
+        List<ServiceInstance> serviceInstances = getServiceInstances(stork, serviceName, 5);
+        assertThat(serviceInstances).hasSize(2);
+
+        ServiceInstance first = serviceInstances.stream().filter(i -> i.getHost().equals(ip1)).findFirst().get();
+        ServiceInstance second = serviceInstances.stream().filter(i -> i.getHost().equals(ip2)).findFirst().get();
+
+        assertThat(first.getPort()).isEqualTo(port1);
+        assertThat(second.getPort()).isEqualTo(port2);
+        assertThat(first.getMetadata().getMetadata().get(DnsMetadataKey.DNS_WEIGHT)).isNotNull();
+        assertThat(second.getPort()).isEqualTo(port2);
+    }
+
+    public static void shouldFetchSRVWithAAAAValues(Stork stork, ConsulClient client, String serviceName,
+            Set<String> registeredConsulServices) throws InterruptedException {
+        // 8333 port won't be included in A record, so the result should have 8111
+        int port1 = 8333;
+        String ip1 = "2001:db8:85a3:0:0:8a2e:370:7334";
+        int port2 = 8334;
+        String ip2 = "2001:db8:85a3:0:0:8a2e:370:7335";
+        registerService(client, registeredConsulServices, serviceName, "[" + ip1 + "]:" + port1, "[" + ip2 + "]:" + port2);
+
+        Service service = stork.getService(serviceName);
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        List<ServiceInstance> serviceInstances = instances.get();
+        assertThat(serviceInstances).hasSize(2);
+
+        ServiceInstance first = serviceInstances.stream().filter(i -> i.getHost().equals(ip1)).findFirst().get();
+        ServiceInstance second = serviceInstances.stream().filter(i -> i.getHost().equals(ip2)).findFirst().get();
+
+        assertThat(first.getPort()).isEqualTo(port1);
+        assertThat(second.getPort()).isEqualTo(port2);
+    }
+
+    public static void shouldFetchAAAA(Stork stork, ConsulClient client, String serviceName,
+            Set<String> registeredConsulServices) throws InterruptedException {
+        // 8333 port won't be included in A record, so the result should have 8111
+        int port1 = 8333;
+        String ip1 = "2001:db8:85a3:0:0:8a2e:370:7334";
+        String ip2 = "2001:db8:85a3:0:0:8a2e:370:7335";
+        registerService(client, registeredConsulServices, serviceName, "[" + ip1 + "]:" + port1, ip2);
+
+        List<ServiceInstance> serviceInstances = getServiceInstances(stork, serviceName, 5);
+
+        assertThat(serviceInstances).hasSize(2);
+
+        ServiceInstance first = serviceInstances.stream().filter(i -> i.getHost().equals(ip1)).findFirst().get();
+        ServiceInstance second = serviceInstances.stream().filter(i -> i.getHost().equals(ip2)).findFirst().get();
+
+        assertThat(first.getPort()).isEqualTo(8111);
+        assertThat(second.getPort()).isEqualTo(8111);
+    }
+
+    public static void shouldRefetchWhenRefreshPeriodReached(Stork stork, Logger log, ConsulClient client, String serviceName,
+            Set<String> registeredConsulServices) throws InterruptedException {
+        registerService(client, registeredConsulServices, serviceName, "127.0.0.5:8406");
+
+        List<ServiceInstance> serviceInstances = getServiceInstances(stork, serviceName, 20);
+
+        assertThat(serviceInstances).isNotEmpty();
+        ServiceInstance firstInstance = serviceInstances.get(0);
+        assertThat(firstInstance.getHost()).isEqualTo("127.0.0.5");
+        long firstInstanceId = firstInstance.getId();
+
+        deregisterServiceInstances(client, log, registeredConsulServices);
+        //the service settings change in consul
+        registerService(client, registeredConsulServices, serviceName, "127.0.0.6:8407", "127.0.0.5:8406");
+
+        Service service = stork.getService(serviceName);
+        // let's wait until the new services are populated to Stork (from DNS)
+        await().atMost(Duration.ofSeconds(7))
+                .until(() -> service.getServiceDiscovery().getServiceInstances().await().indefinitely().size() == 2);
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        serviceInstances = instances.get();
+        assertThat(serviceInstances.stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder(
+                "127.0.0.5", "127.0.0.6");
+        long firstInstanceIdAfterRefetch = serviceInstances.stream()
+                .filter(instance -> instance.getHost().equals("127.0.0.5"))
+                .findFirst()
+                .orElseThrow()
+                .getId();
+        assertThat(firstInstanceId).isEqualTo(firstInstanceIdAfterRefetch);
+
+        ServiceInstance five = serviceInstances.stream().filter(i -> i.getHost().endsWith("5")).findFirst().get();
+        ServiceInstance six = serviceInstances.stream().filter(i -> i.getHost().endsWith("6")).findFirst().get();
+
+        assertThat(five.getPort()).isEqualTo(8406);
+        assertThat(six.getPort()).isEqualTo(8407);
+    }
+
+    public static void shouldRefetchWhenCacheInvalidated(Stork stork, Logger log, ConsulClient client, String serviceName,
+            Set<String> registeredConsulServices) throws InterruptedException {
+
+        Service service = stork.getService(serviceName);
+        registerService(client, registeredConsulServices, serviceName, "127.0.0.5:8406");
+
+        List<ServiceInstance> serviceInstances = getServiceInstances(stork, serviceName, 20);
+
+        assertThat(serviceInstances).isNotEmpty();
+        ServiceInstance firstInstance = serviceInstances.get(0);
+        assertThat(firstInstance.getHost()).isEqualTo("127.0.0.5");
+        assertThat(firstInstance.getPort()).isEqualTo(8406);
+
+        deregisterServiceInstances(client, log, registeredConsulServices);
+
+        //the service settings change
+        registerService(client, registeredConsulServices, serviceName, "127.0.0.6:8407", "127.0.0.5:8406");
+
+        //refresh period not yet reached, we don't get the new settings just registered
+        serviceInstances = getServiceInstances(stork, serviceName, 20);
+
+        assertThat(serviceInstances).isNotEmpty();
+        firstInstance = serviceInstances.get(0);
+        assertThat(firstInstance.getHost()).isEqualTo("127.0.0.5");
+        assertThat(firstInstance.getPort()).isEqualTo(8406);
+
+        //Force cache invalidation
+        DnsServiceDiscovery dnsServiceDiscovery = (DnsServiceDiscovery) service.getServiceDiscovery();
+        dnsServiceDiscovery.invalidate();
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> instances.get() != null);
+
+        serviceInstances = instances.get();
+        assertThat(serviceInstances.stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder(
+                "127.0.0.5", "127.0.0.6");
+        ServiceInstance five = serviceInstances.stream().filter(i -> i.getHost().endsWith("5")).findFirst().get();
+        ServiceInstance six = serviceInstances.stream().filter(i -> i.getHost().endsWith("6")).findFirst().get();
+
+        assertThat(five.getPort()).isEqualTo(8406);
+        assertThat(six.getPort()).isEqualTo(8407);
+    }
+
+    public static String getDnsIp(GenericContainer<?> consul) {
+        @SuppressWarnings("deprecation")
+        String dnsIp = consul.getContainerIpAddress();
+
+        if ("localhost".equals(dnsIp)) {
+            dnsIp = "127.0.0.1";
+        }
+        return dnsIp;
+    }
+
+    public static List<ServiceInstance> getServiceInstances(Stork stork, String serviceName, int timeout) {
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        // call stork service discovery and gather service instances in the cache
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Consul", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(timeout))
+                .until(() -> instances.get() != null);
+        return instances.get();
+    }
+
+    public static void registerService(ConsulClient client, Set<String> registeredConsulServices, String application,
+            String... addresses) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(addresses.length);
+        Set<String> consulServiceIds = new HashSet<>();
+        for (String addressString : addresses) {
+            HostAndPort address = StorkAddressUtils.parseToHostAndPort(addressString, 0, "");
+            String consulServiceId = "" + (consulId++);
+            client.registerService(
+                    new ServiceOptions().setId(consulServiceId).setName(application)
+                            .setAddress(address.host).setPort(address.port))
+                    .onComplete(result -> {
+                        if (result.failed()) {
+                            fail("Failed to register service in Consul " + address, result.cause());
+                        } else {
+                            consulServiceIds.add(consulServiceId);
+                            latch.countDown();
+                        }
+                    });
+        }
+        if (!latch.await(10, TimeUnit.SECONDS)) {
+            fail("Failed to register service in consul in time");
+        }
+        registeredConsulServices.addAll(consulServiceIds);
+    }
+
+    public static void deregisterServiceInstances(ConsulClient client, Logger log, Set<String> registeredConsulServices)
+            throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(registeredConsulServices.size());
+        for (String id : registeredConsulServices) {
+
+            log.info("unregistering service {}", id);
+            client.deregisterService(id, res -> {
+                if (res.succeeded()) {
+                    log.info("unregistered service {}", id);
+                    latch.countDown();
+                } else {
+                    fail("Failed to deregister service in consul", res.cause());
+                }
+            });
+        }
+        if (!latch.await(10, TimeUnit.SECONDS)) {
+            fail("Failed to deregister service in consul in time");
+        }
+        registeredConsulServices.clear();
+    }
+
+    public static boolean clientCanTalkToConsul(ConsulClient client) {
+        var done = new CompletableFuture<>();
+        client.agentInfo().onFailure(done::completeExceptionally)
+                .onSuccess(done::complete);
+        try {
+            done.get();
+            return true;
+        } catch (Exception any) {
+            return false;
+        }
+    }
+
+}

--- a/service-discovery/knative/src/main/java/io/smallrye/stork/servicediscovery/knative/KnativeServiceDiscovery.java
+++ b/service-discovery/knative/src/main/java/io/smallrye/stork/servicediscovery/knative/KnativeServiceDiscovery.java
@@ -99,6 +99,7 @@ public class KnativeServiceDiscovery extends CachingServiceDiscovery {
         return uni.memoize().until(() -> invalidated.get());
     }
 
+    @Override
     public void invalidate() {
         invalidated.set(true);
     }

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
@@ -129,6 +129,7 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
         return uni.memoize().until(() -> invalidated.get());
     }
 
+    @Override
     public void invalidate() {
         invalidated.set(true);
     }

--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryCDITest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryCDITest.java
@@ -568,6 +568,225 @@ public class KubernetesServiceDiscoveryCDITest {
     }
 
     @Test
+    void shouldGetInstancesFromClusterForceCacheInvalidation() throws InterruptedException {
+        String serviceName = "svc";
+
+        //Given a few instances for a svc service
+        List<Endpoints> endpointsList = List
+                .of(registerKubernetesResources(serviceName, defaultNamespace, "10.96.96.231", "10.96.96.232",
+                        "10.96.96.233"));
+
+        //Recording k8s cluster calls and and build the response with the (previous registered) endpoints
+        AtomicInteger serverHit = new AtomicInteger(0);
+        server.expect().get().withPath("/api/v1/namespaces/test/endpoints?fieldSelector=metadata.name%3Dsvc")
+                .andReply(200, r -> {
+                    serverHit.incrementAndGet();
+                    return new EndpointsListBuilder().withItems(endpointsList).build();
+                }).always();
+
+        config.addServiceConfig(serviceName, null, "kubernetes", null,
+                null, Map.of("k8s-host", k8sMasterUrl, "k8s-namespace", defaultNamespace, "refresh-period", "3"), null);
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        Service service = stork.getService(serviceName);
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Kubernetes", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(1);
+        assertThat(instances.get()).hasSize(3);
+        assertThat(instances.get().stream().map(ServiceInstance::getPort)).allMatch(p -> p == 8080);
+        assertThat(instances.get().stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("10.96.96.231",
+                "10.96.96.232", "10.96.96.233");
+
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Kubernetes", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        KubernetesServiceDiscovery kubernetesDiscovery = (KubernetesServiceDiscovery) service.getServiceDiscovery();
+        kubernetesDiscovery.invalidate();
+
+        //second try to get instances, instances should be fetched from cache, cluster calls should be still 1
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Kubernetes", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(2);
+        assertThat(instances.get()).hasSize(3);
+        assertThat(instances.get().stream().map(ServiceInstance::getPort)).allMatch(p -> p == 8080);
+        assertThat(instances.get().stream().map(ServiceInstance::getHost)).containsExactlyInAnyOrder("10.96.96.231",
+                "10.96.96.232", "10.96.96.233");
+
+    }
+
+    /**
+     * Verifies that the cluster is reached when the cache is invalidated. No retries.
+     * The cache is only reset when the call is success but this doesn't trigger multiple calls because retries are not enabled.
+     *
+     * <p>
+     * This test ensures that the system does not enter a loop of cluster calls when the cluster fails,
+     * and that it behaves correctly when the cluster state changes.
+     * </p>
+     */
+    @Test
+    void shouldCallTheClusterWhenCacheInvalidated() throws InterruptedException {
+        String serviceName = "svc";
+
+        //Recording k8s cluster calls and build the response with the (previous registered) endpoints
+        AtomicInteger serverHit = new AtomicInteger(0);
+        server.expect().get().withPath("/api/v1/namespaces/test/endpoints?fieldSelector=metadata.name%3Dsvc")
+                .andReply(500, r -> {
+                    serverHit.incrementAndGet();
+                    return "Internal Server Error";
+                }).always();
+
+        config.addServiceConfig(serviceName, null, "kubernetes", null,
+                null, Map.of("k8s-host", k8sMasterUrl, "k8s-namespace", defaultNamespace, "refresh-period", "3"), null);
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        Service service = stork.getService(serviceName);
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        KubernetesServiceDiscovery serviceDiscovery = (KubernetesServiceDiscovery) service.getServiceDiscovery();
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(1);
+
+        //We trigger an event in the cluster just to invalidate cache
+        registerKubernetesResources(serviceName, defaultNamespace, "10.96.96.231", "10.96.96.232",
+                "10.96.96.233");
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(2);
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        // Since the previous call failed, the cache wasn't reset and we reach the cluster this time incremeting the serverHit to 3.
+        assertThat(serverHit.get()).isEqualTo(3);
+
+        //We trigger an event in the cluster just to invalidate cache
+        registerKubernetesResources("svc2", defaultNamespace, "10.96.96.234", "10.96.96.235",
+                "10.96.96.236");
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(4);
+
+    }
+
+    /**
+     * Verifies that the cluster is reached when the cache is invalidated. With retries.
+     * The cache is only reset when the call is success.
+     *
+     * <p>
+     * This test ensures that the system does only the calls configured by the retries param.
+     * </p>
+     */
+    @Test
+    void shouldCallTheClusterWhenCacheInvalidatedAndRetries() throws InterruptedException {
+        String serviceName = "svc";
+
+        //Recording k8s cluster calls and build the response with the (previous registered) endpoints
+        AtomicInteger serverHit = new AtomicInteger(0);
+        server.expect().get().withPath("/api/v1/namespaces/test/endpoints?fieldSelector=metadata.name%3Dsvc")
+                .andReply(500, r -> {
+                    serverHit.incrementAndGet();
+                    return "Internal Server Error";
+                }).always();
+
+        //We’re using the same retries = 0 configuration as the default because we couldn’t get the test to pass reliably in CI otherwise. In any case, the goal of this test is to verify that the user's configuration overrides the default one — not to test that the Kubernetes client actually performs a specific number of retries.
+        config.addServiceConfig(serviceName, null, "kubernetes", null,
+                null, Map.of("k8s-host", k8sMasterUrl, "k8s-namespace", defaultNamespace, "refresh-period", "3",
+                        "request-retry-backoff-limit", "0"),
+                null);
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        Service service = stork.getService(serviceName);
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        KubernetesServiceDiscovery serviceDiscovery = (KubernetesServiceDiscovery) service.getServiceDiscovery();
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(1);
+
+        //We trigger an event in the cluster just to invalidate cache
+        registerKubernetesResources(serviceName, defaultNamespace, "10.96.96.231", "10.96.96.232",
+                "10.96.96.233");
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(2);
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        // Since the previous call failed, the cache wasn't reset and we reach the cluster this time incremeting the serverHit to 3.
+        assertThat(serverHit.get()).isEqualTo(3);
+
+        //We trigger an event in the cluster just to invalidate cache
+        registerKubernetesResources("svc2", defaultNamespace, "10.96.96.234", "10.96.96.235",
+                "10.96.96.236");
+
+        serviceDiscovery.getServiceInstances()
+                .onFailure().invoke(th -> fail("Expected recovery on failure"))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(serverHit.get()).isEqualTo(4);
+
+    }
+
+    @Test
     void shouldFetchInstancesFromTheClusterWhenCacheIsInvalidated() throws InterruptedException {
 
         // Given a service with 3 instances registered in the cluster, in `test` namespace


### PR DESCRIPTION
Related to https://github.com/smallrye/smallrye-stork/issues/299

It also includes a couple of refactors in some tests. I realised that the tests are not entirely consistent across all service discovery implementations, but I didn't have the courage to do it in all of them...

Even now, I don't think it's worth duplicating the test classes to check the programmatic API. I could have done it in a test method, as is the case with K8s sd, but since I did it for a few classes, I left it as it is...

