### PR TITLE
Remove check about service discovery type null value

### DIFF
--- a/api/src/main/java/io/smallrye/stork/spi/config/SimpleServiceConfig.java
+++ b/api/src/main/java/io/smallrye/stork/spi/config/SimpleServiceConfig.java
@@ -3,7 +3,6 @@ package io.smallrye.stork.spi.config;
 import java.util.Collections;
 import java.util.Map;
 
-import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.stork.api.config.ConfigWithType;
 import io.smallrye.stork.api.config.ServiceConfig;
 
@@ -25,7 +24,7 @@ public class SimpleServiceConfig implements ServiceConfig {
             ConfigWithType serviceDiscoveryConfig, ConfigWithType serviceRegistrarConfig) {
         this.serviceName = serviceName;
         this.loadBalancerConfig = loadBalancerConfig;
-        this.serviceDiscoveryConfig = ParameterValidation.nonNull(serviceDiscoveryConfig, "service discovery type config");
+        this.serviceDiscoveryConfig = serviceDiscoveryConfig;
         this.serviceRegistrarConfig = serviceRegistrarConfig;
     }
 

--- a/api/src/test/java/io/smallrye/config/SimpleServiceConfigOptionalFieldsTest.java
+++ b/api/src/test/java/io/smallrye/config/SimpleServiceConfigOptionalFieldsTest.java
@@ -1,0 +1,85 @@
+package io.smallrye.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.stork.spi.config.SimpleServiceConfig;
+
+class SimpleServiceConfigOptionalFieldsTest {
+
+    @Test
+    void testServiceConfigAllowsNullOptionalConfigs() {
+        String serviceName = "my-service";
+
+        SimpleServiceConfig config = new SimpleServiceConfig.Builder()
+                .setServiceName(serviceName)
+                .build();
+
+        assertEquals(serviceName, config.serviceName());
+        assertNull(config.loadBalancer(), "loadBalancer allowed to be null");
+        assertNull(config.serviceDiscovery(), "serviceDiscovery allowed to be null");
+        assertNull(config.serviceRegistrar(), "serviceRegistrar allowed to be null");
+    }
+
+    @Test
+    void testServiceConfigWithOnlyLoadBalancer() {
+        SimpleServiceConfig.SimpleLoadBalancerConfig lbConfig = new SimpleServiceConfig.SimpleLoadBalancerConfig("lb",
+                java.util.Collections.emptyMap());
+
+        SimpleServiceConfig config = new SimpleServiceConfig.Builder()
+                .setServiceName("with-lb")
+                .setLoadBalancer(lbConfig)
+                .build();
+
+        assertEquals("with-lb", config.serviceName());
+        assertEquals(lbConfig, config.loadBalancer());
+        assertNull(config.serviceDiscovery());
+        assertNull(config.serviceRegistrar());
+    }
+
+    @Test
+    void testServiceConfigWithOnlyServiceDiscovery() {
+        SimpleServiceConfig.SimpleServiceDiscoveryConfig sdConfig = new SimpleServiceConfig.SimpleServiceDiscoveryConfig("sd",
+                java.util.Collections.emptyMap());
+
+        SimpleServiceConfig config = new SimpleServiceConfig.Builder()
+                .setServiceName("with-sd")
+                .setServiceDiscovery(sdConfig)
+                .build();
+
+        assertEquals("with-sd", config.serviceName());
+        assertEquals(sdConfig, config.serviceDiscovery());
+        assertNull(config.loadBalancer());
+        assertNull(config.serviceRegistrar());
+    }
+
+    @Test
+    void testServiceConfigWithOnlyServiceRegistrar() {
+        SimpleServiceConfig.SimpleServiceRegistrarConfig srConfig = new SimpleServiceConfig.SimpleServiceRegistrarConfig("sr",
+                java.util.Collections.emptyMap());
+
+        SimpleServiceConfig config = new SimpleServiceConfig.Builder()
+                .setServiceName("with-sr")
+                .setServiceRegistrar(srConfig)
+                .build();
+
+        assertEquals("with-sr", config.serviceName());
+        assertEquals(srConfig, config.serviceRegistrar());
+        assertNull(config.loadBalancer());
+        assertNull(config.serviceDiscovery());
+    }
+
+    @Test
+    void testFailsIfServiceDiscoveryForcedNonNull() {
+        SimpleServiceConfig.Builder builder = new SimpleServiceConfig.Builder()
+                .setServiceName("my-service");
+
+        try {
+            SimpleServiceConfig config = builder.build();
+            assertNull(config.serviceDiscovery(), "serviceDiscovery allowed to be null");
+        } catch (IllegalArgumentException e) {
+            fail("serviceDiscovery allowed to be null");
+        }
+    }
+}

--- a/microprofile/src/test/java/io/smallrye/stork/microprofile/MicroProfileConfigProviderTest.java
+++ b/microprofile/src/test/java/io/smallrye/stork/microprofile/MicroProfileConfigProviderTest.java
@@ -58,9 +58,8 @@ public class MicroProfileConfigProviderTest {
     }
 
     @Test
-    void shouldConfigureServiceRegistrar() {
+    void shouldConfigureServiceRegistrarOnly() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("stork." + MY_REGISTRAR + ".service-discovery.type", "test-sd-1");
         properties.put("stork." + MY_REGISTRAR + ".service-registrar.type", TestServiceRegistrarProvider.TYPE);
         properties.put("stork." + MY_REGISTRAR + ".service-registrar.param1", "http://localhost:8080");
         properties.put("stork." + MY_REGISTRAR + ".service-registrar.param2", "param2-value");


### PR DESCRIPTION
Since registration became a standalone feature, service discovery configuration is not mandatory anymore.