### PR TITLE
Fix: ensure configuration classes are generated during test compilation

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,6 +90,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+<!--                    This makes the processor available for both compile and test-compile phases, needed here for fixing missing generated classes when using jdk 25-->
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.smallrye.stork</groupId>
+                            <artifactId>stork-configuration-generator</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -304,30 +304,6 @@
                         <excludePackageNames>*.impl:*.impl.*</excludePackageNames>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${plugin.version.compiler}</version>
-                    <executions>
-                        <execution>
-                            <id>default-compile</id>
-                            <phase>compile</phase>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
-                                <annotationProcessorPaths>
-                                    <path>
-                                        <groupId>io.smallrye.stork</groupId>
-                                        <artifactId>stork-configuration-generator</artifactId>
-                                        <version>${project.version}</version>
-                                    </path>
-                                </annotationProcessorPaths>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -389,7 +365,9 @@
         </plugins>
     </build>
 
+
     <modules>
+        <module>config-generator</module>
         <module>api</module>
         <module>bom</module>
         <module>core</module>
@@ -412,7 +390,6 @@
         <module>service-registration/eureka</module>
         <module>test-utils</module>
         <module>docs</module>
-        <module>config-generator</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Fixes #1110 

Moved the annotation processor configuration from inside the <execution> block
to the top-level maven-compiler-plugin configuration. This makes the processor
available for both compile and test-compile phases, fixing missing generated
classes when building tests with Java 25.