### PR TITLE
feat(consul): support TLS for registration

### DIFF
--- a/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrar.java
+++ b/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrar.java
@@ -5,6 +5,7 @@ import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_ID;
 import java.util.List;
 import java.util.Map;
 
+import io.vertx.core.net.JksOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,19 @@ public class ConsulServiceRegistrar implements ServiceRegistrar<ConsulMetadataKe
         ConsulClientOptions options = new ConsulClientOptions();
         options.setHost(config.getConsulHost());
         options.setPort(getPort(serviceName, config.getConsulPort()));
+        if (config.getSsl().equalsIgnoreCase("true")) {
+            options.setSsl(true)
+                    .setTrustStoreOptions(new JksOptions()
+                            .setPath(config.getTrustStorePath())
+                            .setPassword(config.getTrustStorePassword()))
+                    .setKeyStoreOptions(new JksOptions()
+                            .setPath(config.getKeyStorePath())
+                            .setPassword(config.getKeyStorePassword()))
+                    .setAclToken(config.getAclToken());
+            if (config.getVerifyHost().equalsIgnoreCase("true")) {
+                options.setVerifyHost(true);
+            }
+        }
         client = ConsulClient.create(vertx, options);
 
     }

--- a/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrarProvider.java
+++ b/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrarProvider.java
@@ -16,6 +16,13 @@ import io.smallrye.stork.spi.StorkInfrastructure;
 @ServiceRegistrarAttribute(name = "health-check-url", description = "The liveness http address.", defaultValue = "")
 @ServiceRegistrarAttribute(name = "health-check-interval", description = "How often Consul performs the health check", defaultValue = "30s")
 @ServiceRegistrarAttribute(name = "health-check-deregister-after", description = "How long after the check is in critical status Consul will remove the service from the catalogue.", defaultValue = "1m")
+@ServiceRegistrarAttribute(name = "ssl", description = "Whether to enable TLS/SSL when connecting to Consul (default: false)", defaultValue = "false")
+@ServiceRegistrarAttribute(name = "trust-store-path", description = "Path to the trust store file used to verify the Consul server certificate", defaultValue = "")
+@ServiceRegistrarAttribute(name = "trust-store-password", description = "Password of the trust store", defaultValue = "")
+@ServiceRegistrarAttribute(name = "key-store-path", description = "Path to the key store file containing the client certificate and private key", defaultValue = "")
+@ServiceRegistrarAttribute(name = "key-store-password", description = "Password of the key store", defaultValue = "")
+@ServiceRegistrarAttribute(name = "verify-host", description = "Whether to enable hostname verification for the Consul TLS connection (default: false)", defaultValue = "false")
+@ServiceRegistrarAttribute(name = "acl-token", description = "Consul ACL token used for authentication when accessing the Consul API", defaultValue = "")
 public class ConsulServiceRegistrarProvider
         implements ServiceRegistrarProvider<ConsulRegistrarConfiguration, ConsulMetadataKey> {
 


### PR DESCRIPTION
### Background

We are using SmallRye Stork with Consul in production.
In our production environment, Consul is running with TLS enabled.

Currently, Stork Consul registration does not support TLS configuration,
so we added SSL/TLS support and verified it in production.

### What’s included

- Support TLS when registering services to Consul
- Support configuration for:
  - `trust-store-path` (CA file)
  - `trust-store-password`
  - `key-store-path` (client certificate + private key)
  - `key-store-password`
  - `verify-host` (hostname verification)
  - `acl-token` (Consul ACL authentication)
- Backward compatible (non-TLS users are not affected)

### Production status

✅ Already running in production.

### Why this is useful

More and more users deploy Consul in secure (TLS) mode.
This change allows Stork to be used in secure enterprise environments.

## ✅ Example configuration

```properties
quarkus.stork.my-service.service-registrar.ssl=true
quarkus.stork.my-service.service-registrar.trust-store-path=/**/keystore_ca.jks
quarkus.stork.my-service.service-registrar.trust-store-password=xxxxxxx
quarkus.stork.my-service.service-registrar.key-store-path=/**/keystore_ca.jks
quarkus.stork.my-service.service-registrar.key-store-password=xxxxxxx
quarkus.stork.my-service.service-registrar.verify-host=true
quarkus.stork.my-service.service-registrar.acl-token=xxxxxxx