### PR TITLE
feature consul tls registration

### DIFF
--- a/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrar.java
+++ b/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrar.java
@@ -14,6 +14,7 @@ import io.smallrye.stork.api.ServiceRegistrar;
 import io.smallrye.stork.impl.ConsulMetadataKey;
 import io.smallrye.stork.spi.StorkInfrastructure;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.JksOptions;
 import io.vertx.ext.consul.CheckOptions;
 import io.vertx.ext.consul.ConsulClient;
 import io.vertx.ext.consul.ConsulClientOptions;
@@ -34,6 +35,19 @@ public class ConsulServiceRegistrar implements ServiceRegistrar<ConsulMetadataKe
         ConsulClientOptions options = new ConsulClientOptions();
         options.setHost(config.getConsulHost());
         options.setPort(getPort(serviceName, config.getConsulPort()));
+        if (config.getSsl().equalsIgnoreCase("true")) {
+            options.setSsl(true)
+                    .setTrustStoreOptions(new JksOptions()
+                            .setPath(config.getTrustStorePath())
+                            .setPassword(config.getTrustStorePassword()))
+                    .setKeyStoreOptions(new JksOptions()
+                            .setPath(config.getKeyStorePath())
+                            .setPassword(config.getKeyStorePassword()))
+                    .setAclToken(config.getAclToken());
+            if (config.getVerifyHost().equalsIgnoreCase("true")) {
+                options.setVerifyHost(true);
+            }
+        }
         client = ConsulClient.create(vertx, options);
 
     }

--- a/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrarProvider.java
+++ b/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrarProvider.java
@@ -16,6 +16,13 @@ import io.smallrye.stork.spi.StorkInfrastructure;
 @ServiceRegistrarAttribute(name = "health-check-url", description = "The liveness http address.", defaultValue = "")
 @ServiceRegistrarAttribute(name = "health-check-interval", description = "How often Consul performs the health check", defaultValue = "30s")
 @ServiceRegistrarAttribute(name = "health-check-deregister-after", description = "How long after the check is in critical status Consul will remove the service from the catalogue.", defaultValue = "1m")
+@ServiceRegistrarAttribute(name = "ssl", description = "Whether to enable TLS/SSL when connecting to Consul (default: false)", defaultValue = "false")
+@ServiceRegistrarAttribute(name = "trust-store-path", description = "Path to the trust store file used to verify the Consul server certificate", defaultValue = "")
+@ServiceRegistrarAttribute(name = "trust-store-password", description = "Password of the trust store", defaultValue = "")
+@ServiceRegistrarAttribute(name = "key-store-path", description = "Path to the key store file containing the client certificate and private key", defaultValue = "")
+@ServiceRegistrarAttribute(name = "key-store-password", description = "Password of the key store", defaultValue = "")
+@ServiceRegistrarAttribute(name = "verify-host", description = "Whether to enable hostname verification for the Consul TLS connection (default: false)", defaultValue = "false")
+@ServiceRegistrarAttribute(name = "acl-token", description = "Consul ACL token used for authentication when accessing the Consul API", defaultValue = "")
 public class ConsulServiceRegistrarProvider
         implements ServiceRegistrarProvider<ConsulRegistrarConfiguration, ConsulMetadataKey> {
 


### PR DESCRIPTION

## ✅ What’s included

This PR adds full TLS/SSL support for Consul service registration in SmallRye Stork.

### New features:
- Support TLS when registering services to Consul
- Support configuration for:
  - `trust-store-path` (CA file)
  - `trust-store-password`
  - `key-store-path` (client certificate + private key)
  - `key-store-password`
  - `verify-host` (hostname verification)
  - `acl-token` (Consul ACL authentication)

### Behavior:
- Fully backward compatible
- TLS is disabled by default (`ssl=false`)
- No impact on existing non-TLS users

---

## ✅ Why this is needed

In many production environments, Consul runs in secured mode with:
- TLS enabled
- Mutual TLS authentication
- ACL enabled

Without this feature, SmallRye Stork cannot be used in such secure clusters.  
This PR makes Stork usable in **enterprise production environments**.

---

## ✅ Example configuration

```properties
quarkus.stork.my-service.service-registrar.ssl=true
quarkus.stork.my-service.service-registrar.trust-store-path=/**/keystore.jks
quarkus.stork.my-service.service-registrar.trust-store-password=xxxxxxxx
quarkus.stork.my-service.service-registrar.key-store-path=/**/keystore.jks
quarkus.stork.my-service.service-registrar.key-store-password=xxxxxxxx
quarkus.stork.my-service.service-registrar.verify-host=true
quarkus.stork.my-service.service-registrar.acl-token=xxxxxxxx