### PR TITLE
fix: correct hostName, vipAddress and connection host in Eureka

### DIFF
--- a/docs/docs/service-discovery/eureka.md
+++ b/docs/docs/service-discovery/eureka.md
@@ -47,6 +47,7 @@ It uses the Stork service name (`my-service` in the previous configuration) if n
 The `instance` attribute allows selecting a specific instance.
 Using this attribute prevents load-balancing as you will always select a single instance.
 
-The `secure` attribute indicates if you want the _secure virtual address_ of the application instance.
-If set to `true`, unsecured instances are filtered out from the available instances.
+The `secure` attribute indicates whether to connect to instances over TLS.
+If set to `true`, instances without a secure port enabled are filtered out.
+The connection host is always resolved from the `hostName` field of the Eureka instance (falling back to `ipAddr`), regardless of this setting.
 

--- a/docs/docs/service-registration/eureka.md
+++ b/docs/docs/service-registration/eureka.md
@@ -38,6 +38,9 @@ Eureka service registrar is configured with the following parameters:
 
 --8<-- "target/attributes/META-INF/stork-docs/eureka-sr-attributes.txt"
 
+The `ipAddress` passed to `registerServiceInstance()` is used as both the IP address (`ipAddr`) and the hostname (`hostName`) registered in Eureka.
+If the instance has a distinct DNS hostname, set `host-name` explicitly to override this default.
+
 ## Service deregistration configuration
 
 There is no specific configuration required to enable deregistration; however, you must ensure that a consul service registrar is configured for the service:

--- a/service-discovery/eureka/src/main/java/io/smallrye/stork/servicediscovery/eureka/EurekaServiceDiscovery.java
+++ b/service-discovery/eureka/src/main/java/io/smallrye/stork/servicediscovery/eureka/EurekaServiceDiscovery.java
@@ -100,22 +100,15 @@ public class EurekaServiceDiscovery extends CachingServiceDiscovery {
             List<ServiceInstance> previousInstances) {
         return instances
                 .map(instance -> {
-                    String virtualAddress;
-                    int port;
-
-                    if (secure && instance.securePort.enabled) {
-                        virtualAddress = instance.secureVipAddress;
-                        if (virtualAddress == null) {
-                            virtualAddress = instance.vipAddress;
-                        }
-                        port = instance.securePort.port;
-                    } else {
-                        virtualAddress = instance.vipAddress;
-                        port = instance.port.port;
-                    }
-                    ServiceInstance matching = ServiceInstanceUtils.findMatching(previousInstances, virtualAddress, port);
+                    String host = instance.hostName != null && !instance.hostName.isBlank()
+                            ? instance.hostName
+                            : instance.ipAddr;
+                    int port = secure && instance.securePort.enabled
+                            ? instance.securePort.port
+                            : instance.port.port;
+                    ServiceInstance matching = ServiceInstanceUtils.findMatching(previousInstances, host, port);
                     return matching == null
-                            ? new DefaultServiceInstance(ServiceInstanceIds.next(), virtualAddress, port, secure)
+                            ? new DefaultServiceInstance(ServiceInstanceIds.next(), host, port, secure)
                             : matching;
                 })
                 .collect(Collectors.toList());

--- a/service-discovery/eureka/src/test/java/io/smallrye/stork/servicediscovery/eureka/EurekaDiscoveryCDITest.java
+++ b/service-discovery/eureka/src/test/java/io/smallrye/stork/servicediscovery/eureka/EurekaDiscoveryCDITest.java
@@ -154,7 +154,7 @@ public class EurekaDiscoveryCDITest {
         List<ServiceInstance> instances = service.getInstances().await().atMost(Duration.ofSeconds(5));
         assertThat(instances).hasSize(2)
                 .anySatisfy(instance -> {
-                    assertThat(instance.getHost()).isEqualTo("secure.acme.com");
+                    assertThat(instance.getHost()).isEqualTo("acme.com");
                     assertThat(instance.getPort()).isEqualTo(433);
                     assertThat(instance.isSecure()).isTrue();
                 })
@@ -287,7 +287,7 @@ public class EurekaDiscoveryCDITest {
         List<ServiceInstance> instances = service.getInstances().await().atMost(Duration.ofSeconds(5));
         assertThat(instances).hasSize(1)
                 .anySatisfy(instance -> {
-                    assertThat(instance.getHost()).isEqualTo("ssl.acme.com");
+                    assertThat(instance.getHost()).isEqualTo("acme2.com");
                     assertThat(instance.getPort()).isEqualTo(433);
                 });
     }

--- a/service-discovery/eureka/src/test/java/io/smallrye/stork/servicediscovery/eureka/EurekaDiscoveryTest.java
+++ b/service-discovery/eureka/src/test/java/io/smallrye/stork/servicediscovery/eureka/EurekaDiscoveryTest.java
@@ -9,8 +9,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -148,7 +148,7 @@ public class EurekaDiscoveryTest {
         List<ServiceInstance> instances = service.getInstances().await().atMost(Duration.ofSeconds(5));
         assertThat(instances).hasSize(2)
                 .anySatisfy(instance -> {
-                    assertThat(instance.getHost()).isEqualTo("secure.acme.com");
+                    assertThat(instance.getHost()).isEqualTo("acme.com");
                     assertThat(instance.getPort()).isEqualTo(433);
                     assertThat(instance.isSecure()).isTrue();
                 })
@@ -281,7 +281,7 @@ public class EurekaDiscoveryTest {
         List<ServiceInstance> instances = service.getInstances().await().atMost(Duration.ofSeconds(5));
         assertThat(instances).hasSize(1)
                 .anySatisfy(instance -> {
-                    assertThat(instance.getHost()).isEqualTo("ssl.acme.com");
+                    assertThat(instance.getHost()).isEqualTo("acme2.com");
                     assertThat(instance.getPort()).isEqualTo(433);
                 });
     }
@@ -387,11 +387,11 @@ public class EurekaDiscoveryTest {
         JsonObject registration = new JsonObject();
         instance.put("instance", registration);
         registration
-                .put("hostName", "localhost")
+                .put("hostName", virtualAddress)
                 .put("instanceId", instanceId)
                 .put("app", applicationId)
                 .put("ipAddr", "1.1.1." + port)
-                .put("vipAddress", virtualAddress)
+                .put("vipAddress", applicationId)
                 .put("port", new JsonObject().put("$", port).put("@enabled", "true"));
 
         if (secureVirtualAddress != null) {

--- a/service-registration/eureka/src/main/java/io/smallrye/stork/serviceregistration/eureka/EurekaServiceRegistrar.java
+++ b/service-registration/eureka/src/main/java/io/smallrye/stork/serviceregistration/eureka/EurekaServiceRegistrar.java
@@ -93,15 +93,16 @@ public class EurekaServiceRegistrar implements ServiceRegistrar<EurekaMetadataKe
     private Uni<Void> registerApplicationInstance(WebClient client, String applicationId, String instanceId,
             String ipAddress, String virtualAddress, int port,
             String secureVirtualAddress, int securePort, String state, Map<String, String> metadata) {
+        String hostName = config.getHostName() != null && !config.getHostName().isBlank() ? config.getHostName() : ipAddress;
         JsonObject instance = new JsonObject();
         JsonObject registration = new JsonObject();
         instance.put("instance", registration);
         registration
-                .put("hostName", "localhost")
+                .put("hostName", hostName)
                 .put("instanceId", instanceId)
                 .put("app", applicationId)
                 .put("ipAddr", ipAddress)
-                .put("vipAddress", virtualAddress)
+                .put("vipAddress", virtualAddress != null ? virtualAddress : applicationId)
                 .put("port", new JsonObject().put("$", port).put("@enabled", "true"));
 
         if (secureVirtualAddress != null) {

--- a/service-registration/eureka/src/main/java/io/smallrye/stork/serviceregistration/eureka/EurekaServiceRegistrarProvider.java
+++ b/service-registration/eureka/src/main/java/io/smallrye/stork/serviceregistration/eureka/EurekaServiceRegistrarProvider.java
@@ -16,6 +16,7 @@ import io.smallrye.stork.spi.StorkInfrastructure;
 @ServiceRegistrarAttribute(name = "eureka-trust-all", description = "Enable/Disable the TLS certificate verification", defaultValue = "false")
 @ServiceRegistrarAttribute(name = "eureka-tls", description = "Use TLS to connect to the Eureka server", defaultValue = "false")
 @ServiceRegistrarAttribute(name = "health-check-url", description = "The liveness http address.", defaultValue = "")
+@ServiceRegistrarAttribute(name = "host-name", description = "The host name to register in Eureka. If not set, the ipAddress is used.", defaultValue = "")
 @ApplicationScoped
 public class EurekaServiceRegistrarProvider
         implements ServiceRegistrarProvider<EurekaRegistrarConfiguration, EurekaMetadataKey> {

--- a/service-registration/eureka/src/test/java/io/smallrye/stork/serviceregistration/eureka/EurekaRegistrationTest.java
+++ b/service-registration/eureka/src/test/java/io/smallrye/stork/serviceregistration/eureka/EurekaRegistrationTest.java
@@ -83,7 +83,7 @@ public class EurekaRegistrationTest {
         CountDownLatch registrationLatch = new CountDownLatch(1);
 
         eurekaServiceRegistrar.registerServiceInstance(serviceName, Metadata.of(EurekaMetadataKey.class)
-                .with(EurekaMetadataKey.META_EUREKA_SERVICE_ID, serviceName), "localhost", 8406).subscribe()
+                .with(EurekaMetadataKey.META_EUREKA_SERVICE_ID, serviceName), "myServiceAddress", 8406).subscribe()
                 .with(success -> registrationLatch.countDown(), failure -> fail(""));
 
         await().atMost(Duration.ofSeconds(10))
@@ -104,7 +104,9 @@ public class EurekaRegistrationTest {
         JsonObject jsonServiceInstance = application.getJsonArray("instance").getJsonObject(0);
 
         assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
-        assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
+        assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("myServiceAddress");
+        assertThat(jsonServiceInstance.getString("hostName")).isEqualTo("myServiceAddress");
+        assertThat(jsonServiceInstance.getString("vipAddress")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
         assertThat(jsonServiceInstance.getString("healthCheckUrl")).isEqualTo("/q/health/live");
 
@@ -148,6 +150,7 @@ public class EurekaRegistrationTest {
 
         assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
+        assertThat(jsonServiceInstance.getString("vipAddress")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
         assertThat(jsonServiceInstance.getString("healthCheckUrl")).isEqualTo("/q/health/live");
         assertThat(jsonServiceInstance.getJsonObject("metadata").getString("protocol")).isEqualTo("https");
@@ -190,6 +193,7 @@ public class EurekaRegistrationTest {
 
         assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
+        assertThat(jsonServiceInstance.getString("vipAddress")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
 
     }
@@ -250,6 +254,7 @@ public class EurekaRegistrationTest {
 
         assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
+        assertThat(jsonServiceInstance.getString("vipAddress")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
         CountDownLatch deregistrationLatch = new CountDownLatch(1);
         eurekaServiceRegistrar.deregisterServiceInstance(serviceName)


### PR DESCRIPTION
`EurekaServiceRegistrar` was hardcoding `hostName` to `"localhost"` regardless of the registered instance address; now uses `ipAddress` (or `host-name` config attribute if explicitly set).
`EurekaServiceRegistrar` was sending `vipAddress: null`; now defaults to the application/service name, which is the correct semantic in the Eureka ecosystem. 
`EurekaServiceDiscovery` was using `vipAddress` as the connection hostname for discovered instances; now uses  `hostName` (falling back to `ipAddr`), which is the actual routable address.