### PR TITLE
Add permissions to post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -6,6 +6,10 @@ on:
       - "!*"
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
 jobs:
   post-release:
     runs-on: ubuntu-latest
@@ -20,25 +24,21 @@ jobs:
           java-version: 21
           distribution: temurin
           cache: maven       
+
       - name: Build local artifacts
-        run: mvn -B install -DskipTests  
+        run: mvn -B install -DskipTests
+
+      - name: Setup JBang
+        uses: jbangdev/setup-jbang@main
+
       - name: Collect breaking changes
         run:  |
-          sudo apt-get update -o Dir::Etc::sourcelist="sources.list" \
-            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-          sudo apt-get install -y gnupg2 gnupg-agent
-          curl -s "https://get.sdkman.io" | bash
-          source ~/.sdkman/bin/sdkman-init.sh && \
-            sdk install jbang  
           mkdir -p target
           jbang .github/CompatibilityUtils.java extract
+
       - name: Update release notes
-        env:
-            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          sudo apt-get install -y gnupg2 gnupg-agent
-          curl -s "https://get.sdkman.io" | bash
-          source ~/.sdkman/bin/sdkman-init.sh && \
-            sdk install jbang  
           export STORK_VERSION=$(cat ".github/project.yml" | yq eval '.release.current-version' -)  
           jbang .github/PublishReleaseNotes.java --release-version=$STORK_VERSION --token=$GITHUB_TOKEN
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The workflow updates GitHub release notes, which requires
contents: write. Also switch from RELEASE_TOKEN to the built-in
GITHUB_TOKEN now that the correct permission scope is declared.

Use jbangdev/setup-jbang action instead of manual sdkman installation.
