### PR TITLE
Cache the result of shouldUseEndpointSlices() in a field during construction and reuse it

### DIFF
--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
@@ -29,7 +29,6 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.discovery.v1.Endpoint;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSlice;
-import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSliceList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -70,6 +69,7 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
     private final int requestRetryBackoffLimit;
     private final int requestRetryBackoffInterval;
     private final Boolean useEndpointSlices;
+    private final boolean useEndpointSlicesEnabled;
     private final boolean useClusterIp;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesServiceDiscovery.class);
@@ -112,6 +112,7 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
         this.secure = isSecure(config);
         this.useEndpointSlices = config.getUseEndpointSlices() == null ? null
                 : Boolean.valueOf(config.getUseEndpointSlices());
+        this.useEndpointSlicesEnabled = shouldUseEndpointSlices();
         this.useClusterIp = config.getUseClusterIp() != null && Boolean.parseBoolean(config.getUseClusterIp());
         if (useClusterIp && Boolean.TRUE.equals(useEndpointSlices)) {
             LOGGER.warn("Both 'use-cluster-ip' and 'use-endpoint-slices' are enabled for service '{}'. "
@@ -119,7 +120,7 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
         }
         if (useClusterIp) {
             configureServicesInformer();
-        } else if (shouldUseEndpointSlices()) {
+        } else if (useEndpointSlicesEnabled) {
             configureSlicesInformer();
         } else {
             configureEndpointsInformer();
@@ -155,15 +156,8 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
             return false; // old cluster - endpoints
         }
 
-        EndpointSliceList slices = client.discovery().v1().endpointSlices()
-                .inNamespace(namespace)
-                .withLabel(SERVICE_SELECTOR, application)
-                .list();
-        boolean shouldUseEndpointSlices = slices != null && !slices.getItems().isEmpty();
-        if (shouldUseEndpointSlices) {
-            LOGGER.info("EndpointSlice discovery is enabled (experimental)");
-        }
-        return shouldUseEndpointSlices;
+        LOGGER.info("EndpointSlice discovery is enabled (experimental)");
+        return apiAvailable;
     }
 
     private void configureEndpointsInformer() {
@@ -251,7 +245,7 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
         if (useClusterIp) {
             result = fetchServiceClusterIp().onItem()
                     .transform(clusterIps -> fromClusterIpServicesToStorkServiceInstances(clusterIps, previousInstances));
-        } else if (shouldUseEndpointSlices()) {
+        } else if (useEndpointSlicesEnabled) {
             result = fetchServiceEndpointSlice().onItem()
                     .transform(slices -> fromSlicesToStorkServiceInstances(slices, previousInstances));
         } else {

--- a/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
+++ b/service-discovery/kubernetes/src/main/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscovery.java
@@ -135,7 +135,7 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
      * </p>
      * <ol>
      * <li>User config: if {@code use-endpoint-slices} is explicitly set, that value is used.</li>
-     * <li>If not set, use EndpointSlices only when the API is available and the service has slices.</li>
+     * <li>If not set, use EndpointSlices only when the API is available.</li>
      * <li>Otherwise fall back to classic Endpoints.</li>
      * </ol>
      *
@@ -157,7 +157,7 @@ public class KubernetesServiceDiscovery extends CachingServiceDiscovery {
         }
 
         LOGGER.info("EndpointSlice discovery is enabled (experimental)");
-        return apiAvailable;
+        return true;
     }
 
     private void configureEndpointsInformer() {

--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryTest.java
@@ -601,7 +601,7 @@ public class KubernetesServiceDiscoveryTest {
         KubernetesServiceDiscovery kubernetesDiscovery = (KubernetesServiceDiscovery) service.getServiceDiscovery();
         kubernetesDiscovery.invalidate();
 
-        //second try to get instances, instances should be fetched from cache, cluster calls should be still 1
+        //second try to get instances, instances should be fetched from cluster, calls should be 2
         service.getServiceDiscovery().getServiceInstances()
                 .onFailure().invoke(th -> fail("Failed to get service instances from Kubernetes", th))
                 .subscribe().with(instances::set);

--- a/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryWithSlicesTest.java
+++ b/service-discovery/kubernetes/src/test/java/io/smallrye/stork/servicediscovery/kubernetes/KubernetesServiceDiscoveryWithSlicesTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +27,7 @@ import io.fabric8.kubernetes.api.model.discovery.v1.EndpointBuilder;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointConditionsBuilder;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSlice;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSliceBuilder;
+import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSliceListBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -76,14 +78,13 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
                         "use-endpoint-slices", "true"),
                 null);
 
-        Stork stork = StorkTestUtils.getNewStorkInstance();
-        whenGetSlicesApiAvailableThenReturnTrue();
-
         String serviceName = "svc";
         String[] ips = { "10.96.96.231" };
         EndpointPort[] ports = { new EndpointPort("http", 8080) };
 
+        whenGetSlicesApiAvailableThenReturnTrue();
         registerKubernetesEndpointSlice(serviceName, "test", ips, ports);
+        Stork stork = StorkTestUtils.getNewStorkInstance();
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -126,9 +127,6 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
                         "use-endpoint-slices", "true"),
                 null);
 
-        Stork stork = StorkTestUtils.getNewStorkInstance();
-        whenGetSlicesApiAvailableThenReturnTrue();
-
         String serviceName = "svc";
         String[] ips1 = { "10.96.96.231" };
         EndpointPort[] ports1 = { new EndpointPort("http", 8080) };
@@ -136,8 +134,10 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
         String[] ips2 = { "10.96.96.232" };
         EndpointPort[] ports2 = { new EndpointPort("metrics", 9090) };
 
+        whenGetSlicesApiAvailableThenReturnTrue();
         registerKubernetesEndpointSlice(serviceName, "test", ips1, ports1);
         registerKubernetesEndpointSlice(serviceName, "test", ips2, ports2);
+        Stork stork = StorkTestUtils.getNewStorkInstance();
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -180,14 +180,13 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
                         "use-endpoint-slices", "true"),
                 null);
 
-        Stork stork = StorkTestUtils.getNewStorkInstance();
-        whenGetSlicesApiAvailableThenReturnTrue();
-
         String serviceName = "svc";
         String[] ips1 = { "10.96.96.231", "10.96.96.232" };
         EndpointPort[] ports1 = { new EndpointPort("http", 8080) };
 
+        whenGetSlicesApiAvailableThenReturnTrue();
         registerKubernetesEndpointSlice(serviceName, "test", ips1, ports1);
+        Stork stork = StorkTestUtils.getNewStorkInstance();
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -230,10 +229,6 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
                         "use-endpoint-slices", "true"),
                 null);
 
-        Stork stork = StorkTestUtils.getNewStorkInstance();
-
-        whenGetSlicesApiAvailableThenReturnTrue();
-
         String serviceName = "svc";
         String[] ips1 = { "10.96.96.231", "10.96.96.232" };
         EndpointPort[] ports1 = { new EndpointPort("http", 8080), new EndpointPort("management", 8081) };
@@ -241,8 +236,10 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
         String[] ips2 = { "10.96.96.232" };
         EndpointPort[] ports2 = { new EndpointPort("metrics", 9090) };
 
+        whenGetSlicesApiAvailableThenReturnTrue();
         registerKubernetesEndpointSlice(serviceName, "test", ips1, ports1);
         registerKubernetesEndpointSlice(serviceName, "test", ips2, ports2);
+        Stork stork = StorkTestUtils.getNewStorkInstance();
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -291,22 +288,15 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
 
         whenGetSlicesApiAvailableThenReturnTrue();
 
-        String serviceNameSlice = "svc";
         String[] ipsSlice = { "10.0.0.99" }; // <- this ip should be ignored, because the user disabled EndpointSlices
-        EndpointPort[] portsSlice = { new EndpointPort("http", 8080) };
-        registerKubernetesEndpointSlice(serviceNameSlice, "test", ipsSlice, portsSlice);
+        EndpointPort[] portsSlice = { new EndpointPort("http", 9090) };
+        registerKubernetesEndpointSlice("svc", "test", ipsSlice, portsSlice);
 
-        String serviceName = "svc";
-        String[] endpointIps = { "10.0.0.2" };
-        String[] sliceIps = { "10.0.0.99" };
-        EndpointPort[] slicePorts = { new EndpointPort("http", 9090) };
-
-        utils.registerKubernetesLegacyEndpointsResources(serviceName, defaultNamespace, endpointIps);
-        registerKubernetesEndpointSlice(serviceName, defaultNamespace, sliceIps, slicePorts);
+        utils.registerKubernetesLegacyEndpointsResources("svc", defaultNamespace, "10.0.0.2");
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
-        stork.getService(serviceName)
+        stork.getService("svc")
                 .getServiceDiscovery()
                 .getServiceInstances()
                 .subscribe().with(instances::set);
@@ -328,15 +318,14 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
                         "k8s-namespace", defaultNamespace),
                 null);
 
-        Stork stork = StorkTestUtils.getNewStorkInstance();
-
         String serviceName = "svc";
         String[] ips = { "10.0.0.3" };
         EndpointPort[] ports = { new EndpointPort("http", 8080) };
 
         whenGetSlicesApiAvailableThenReturnTrue();
-
         registerKubernetesEndpointSlice(serviceName, defaultNamespace, ips, ports);
+
+        Stork stork = StorkTestUtils.getNewStorkInstance();
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -363,14 +352,14 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
                         "port-name", "http",
                         "use-endpoint-slices", "true"),
                 null);
-        Stork stork = StorkTestUtils.getNewStorkInstance();
-
         whenGetSlicesApiAvailableThenReturnTrue();
 
-        String[] ips1 = { "10.96.96.231", "10.96.96.232" };
-        EndpointPort[] ports1 = { new EndpointPort("http", 8080), new EndpointPort("management", 8081) };
+        String[] ips = { "10.96.96.231", "10.96.96.232" };
+        EndpointPort[] ports = { new EndpointPort("http", 8080), new EndpointPort("management", 8081) };
 
-        registerKubernetesEndpointSlice(serviceName, "ns1", ips1, ports1);
+        registerKubernetesEndpointSlice(serviceName, "ns1", ips, ports);
+
+        Stork stork = StorkTestUtils.getNewStorkInstance();
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
@@ -430,6 +419,32 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
         assertThat(instances.get()).hasSize(0);
     }
 
+    @Test
+    void shouldReturnEmptyListWhenNoEndpointSlicesExist() {
+        TestConfigProvider.addServiceConfig("svc", null, "kubernetes", null,
+                null,
+                Map.of(
+                        "k8s-host", k8sMasterUrl,
+                        "k8s-namespace", defaultNamespace,
+                        "use-endpoint-slices", "true"),
+                null);
+
+        whenGetSlicesApiAvailableThenReturnTrue();
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
+
+        stork.getService("svc")
+                .getServiceDiscovery()
+                .getServiceInstances()
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(instances.get()).isEmpty();
+    }
+
     private void whenGetSlicesApiAvailableThenReturnTrue() {
         server.expect()
                 .get()
@@ -483,28 +498,71 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
     }
 
     @Test
-    void shouldReturnEmptyListWhenNoEndpointSlicesExist() {
-        TestConfigProvider.addServiceConfig("svc", null, "kubernetes", null,
-                null,
-                Map.of(
-                        "k8s-host", k8sMasterUrl,
-                        "k8s-namespace", defaultNamespace,
-                        "use-endpoint-slices", "true"),
-                null);
+    void shouldNotCallClusterForAutodetectionOnCacheRefresh() {
+        String serviceName = "svc";
+        String[] ips = { "10.96.96.231" };
+        EndpointPort[] ports = { new EndpointPort("http", 8080) };
+        EndpointSlice endpointSlice = registerKubernetesEndpointSlice(serviceName, defaultNamespace, ips, ports);
 
+        AtomicInteger clusterHits = new AtomicInteger(0);
+        server.expect()
+                .get()
+                .withPath(
+                        "/apis/discovery.k8s.io/v1/namespaces/test/endpointslices?labelSelector=kubernetes.io%2Fservice-name%3Dsvc")
+                .andReply(200, r -> {
+                    clusterHits.incrementAndGet();
+                    return new EndpointSliceListBuilder().withItems(endpointSlice).build();
+
+                })
+                .always();
+
+        whenGetSlicesApiAvailableThenReturnTrue();
+
+        TestConfigProvider.addServiceConfig(serviceName, null, "kubernetes", null,
+                null,
+                Map.of("k8s-host", k8sMasterUrl, "k8s-namespace", defaultNamespace,
+                        "refresh-period", "3"),
+                null);
         Stork stork = StorkTestUtils.getNewStorkInstance();
 
         AtomicReference<List<ServiceInstance>> instances = new AtomicReference<>();
 
-        stork.getService("svc")
-                .getServiceDiscovery()
-                .getServiceInstances()
+        Service service = stork.getService(serviceName);
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Kubernetes (EndpointSlices)", th))
                 .subscribe().with(instances::set);
 
         await().atMost(Duration.ofSeconds(5))
                 .until(() -> instances.get() != null);
 
-        assertThat(instances.get()).isEmpty();
+        assertThat(clusterHits.get()).isEqualTo(1);
+        assertThat(instances.get()).hasSize(1);
+
+        // second call: instances should come from cache, no additional /apis call
+        instances.set(null);
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Kubernetes (EndpointSlices)", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(clusterHits.get()).isEqualTo(1);
+        assertThat(instances.get()).hasSize(1);
+
+        KubernetesServiceDiscovery kubernetesDiscovery = (KubernetesServiceDiscovery) service.getServiceDiscovery();
+        kubernetesDiscovery.invalidate();
+
+        instances.set(null);
+        service.getServiceDiscovery().getServiceInstances()
+                .onFailure().invoke(th -> fail("Failed to get service instances from Kubernetes (EndpointSlices)", th))
+                .subscribe().with(instances::set);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> instances.get() != null);
+
+        assertThat(clusterHits.get()).isEqualTo(2);
+        assertThat(instances.get()).hasSize(1);
     }
 
     /**
@@ -521,7 +579,8 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
      * @param ips the IP addresses exposed by the service
      * @param ports the ports exposed by those IPs
      */
-    private void registerKubernetesEndpointSlice(String serviceName, String namespace, String[] ips, EndpointPort[] ports) {
+    private EndpointSlice registerKubernetesEndpointSlice(String serviceName, String namespace, String[] ips,
+            EndpointPort[] ports) {
         List<io.fabric8.kubernetes.api.model.discovery.v1.EndpointPort> portList = new ArrayList<>();
         for (EndpointPort port : ports) {
             portList.add(new io.fabric8.kubernetes.api.model.discovery.v1.EndpointPortBuilder().withPort(port.portNumber())
@@ -548,6 +607,7 @@ public class KubernetesServiceDiscoveryWithSlicesTest {
                 .inNamespace(namespace)
                 .resource(slice)
                 .create();
+        return slice;
 
     }
 


### PR DESCRIPTION
Fixes #1231 

cc [jdussouillez](https://github.com/jdussouillez)