### PR TITLE
 Fix multiple instances overriding each other when registering with consul

### DIFF
--- a/api/revapi.json
+++ b/api/revapi.json
@@ -32,7 +32,13 @@
         "ignore": true,
         "code": "java.method.addedToInterface",
         "new": "method io.smallrye.mutiny.Uni<java.lang.Void> io.smallrye.stork.api.ServiceRegistrar<MetadataKeyType extends java.lang.Enum<MetadataKeyType> & io.smallrye.stork.api.MetadataKey>::deregisterServiceInstance(java.lang.String)",
-        "justification": "The method has bee added to extend the capabilities of the ServiceRegistrar interface by providing support for service deregistration. It is a backward-compatible change, as it adds a default method to the interface and does not break existing implementations."
+        "justification": "The method has been added to extend the capabilities of the ServiceRegistrar interface by providing support for service deregistration. It is a backward-compatible change, as it adds a default method to the interface and does not break existing implementations."
+      },
+      {
+        "ignore": true,
+        "code": "java.method.addedToInterface",
+        "new": "method io.smallrye.mutiny.Uni<java.lang.Void> io.smallrye.stork.api.ServiceRegistrar<MetadataKeyType extends java.lang.Enum<MetadataKeyType> & io.smallrye.stork.api.MetadataKey>::registerServiceInstance(java.lang.String, java.lang.String, io.smallrye.stork.api.Metadata<MetadataKeyType>, java.lang.String, int)",
+        "justification": "Added instanceName parameter to allow deterministic instance ID generation, required to fix deregistration bugs in backends like Consul."
       }
     ]
   }

--- a/api/src/main/java/io/smallrye/stork/api/Metadata.java
+++ b/api/src/main/java/io/smallrye/stork/api/Metadata.java
@@ -2,6 +2,7 @@ package io.smallrye.stork.api;
 
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -95,6 +96,18 @@ public class Metadata<T extends Enum<T> & MetadataKey> {
      */
     public EnumMap<T, Object> getMetadata() {
         return metadata;
+    }
+
+    /**
+     * @return the metadata as a {@code Map<String, String>}, using each key's name and converting values via
+     *         {@code toString()}
+     */
+    public Map<String, String> asMap() {
+        Map<String, String> result = new HashMap<>();
+        for (Map.Entry<T, Object> entry : metadata.entrySet()) {
+            result.put(entry.getKey().getName(), entry.getValue() != null ? entry.getValue().toString() : null);
+        }
+        return result;
     }
 
     /**

--- a/api/src/main/java/io/smallrye/stork/api/Service.java
+++ b/api/src/main/java/io/smallrye/stork/api/Service.java
@@ -231,16 +231,75 @@ public class Service {
         return serviceRegistrar;
     }
 
+    /**
+     * Registers a service instance identified by its IP address and port.
+     *
+     * @param serviceName the name of the service
+     * @param ipAddress the IP address of the instance
+     * @param port the port of the instance
+     * @return a {@link Uni} completing when the registration is done
+     */
     public Uni<Void> registerInstance(String serviceName, String ipAddress, int port) {
         return serviceRegistrar.registerServiceInstance(serviceName, ipAddress, port);
     }
 
+    /**
+     * Registers a service instance with an explicit instance name used as the registration ID.
+     *
+     * @param serviceName the name of the service
+     * @param instanceName the unique identifier for this instance in the registry
+     * @param ipAddress the IP address of the instance
+     * @param port the port of the instance
+     * @return a {@link Uni} completing when the registration is done
+     */
+    public Uni<Void> registerInstance(String serviceName, String instanceName, String ipAddress, int port) {
+        return serviceRegistrar.registerServiceInstance(serviceName, instanceName, Metadata.empty(), ipAddress, port);
+    }
+
+    /**
+     * Registers a service instance using the provided options (tags, metadata, etc.).
+     *
+     * @param options the registration options
+     * @return a {@link Uni} completing when the registration is done
+     */
     public Uni<Void> registerInstance(ServiceRegistrar.RegistrarOptions options) {
         return serviceRegistrar.registerServiceInstance(options);
     }
 
+    /**
+     * Deregisters all instances of the given service.
+     *
+     * @param serviceName the name of the service
+     * @return a {@link Uni} completing when the deregistration is done
+     * @deprecated Prefer {@link #deregisterServiceInstance(String, String)} or
+     *             {@link #deregisterServiceInstance(String, String, int)} to target a specific instance.
+     */
+    @Deprecated
     public Uni<Void> deregisterServiceInstance(String serviceName) {
         return serviceRegistrar.deregisterServiceInstance(serviceName);
+    }
+
+    /**
+     * Deregisters the service instance identified by the given IP address and port.
+     *
+     * @param serviceName the name of the service
+     * @param ipAddress the IP address of the instance to deregister
+     * @param port the port of the instance to deregister
+     * @return a {@link Uni} completing when the deregistration is done
+     */
+    public Uni<Void> deregisterServiceInstance(String serviceName, String ipAddress, int port) {
+        return serviceRegistrar.deregisterServiceInstance(serviceName, ipAddress, port);
+    }
+
+    /**
+     * Deregisters the service instance identified by the given instance name.
+     *
+     * @param serviceName the name of the service
+     * @param instanceName the registration ID of the instance to deregister
+     * @return a {@link Uni} completing when the deregistration is done
+     */
+    public Uni<Void> deregisterServiceInstance(String serviceName, String instanceName) {
+        return serviceRegistrar.deregisterServiceInstance(serviceName, instanceName);
     }
 
     public ObservationCollector getObservations() {

--- a/api/src/main/java/io/smallrye/stork/api/ServiceRegistrar.java
+++ b/api/src/main/java/io/smallrye/stork/api/ServiceRegistrar.java
@@ -18,14 +18,25 @@ public interface ServiceRegistrar<MetadataKeyType extends Enum<MetadataKeyType> 
         }
     }
 
+    default void checkInstanceNameNotNull(String instanceName) {
+        if (instanceName == null || instanceName.isEmpty() || instanceName.isBlank()) {
+            throw new IllegalArgumentException("Parameter instanceName should be provided.");
+        }
+    }
+
     default void checkRegistrarOptionsNotNull(RegistrarOptions options) {
         if (options == null) {
             throw new IllegalArgumentException("Parameter registrar options should be provided.");
         }
     }
 
-    Uni<Void> registerServiceInstance(String serviceName, Metadata<MetadataKeyType> metadata, String ipAddress,
-            int defaultPort);
+    default Uni<Void> registerServiceInstance(String serviceName, Metadata<MetadataKeyType> metadata, String ipAddress,
+            int defaultPort) {
+        return registerServiceInstance(serviceName, null, metadata, ipAddress, defaultPort);
+    }
+
+    Uni<Void> registerServiceInstance(String serviceName, String instanceName, Metadata<MetadataKeyType> metadata,
+            String ipAddress, int defaultPort);
 
     default Uni<Void> registerServiceInstance(RegistrarOptions options) {
         checkRegistrarOptionsNotNull(options);
@@ -34,7 +45,28 @@ public interface ServiceRegistrar<MetadataKeyType extends Enum<MetadataKeyType> 
         return registerServiceInstance(options.serviceName(), options.ipAddress(), options.defaultPort());
     }
 
+    @Deprecated
     Uni<Void> deregisterServiceInstance(String serviceName);
+
+    /**
+     * Deregisters a specific service instance identified by instance name.
+     * Implementors SHOULD override this method.
+     * The default implementation falls back to {@link #deregisterServiceInstance(String)},
+     * which may deregister ALL instances of the service.
+     */
+    default Uni<Void> deregisterServiceInstance(String serviceName, String instanceName) {
+        return deregisterServiceInstance(serviceName);
+    }
+
+    /**
+     * Deregisters a specific service instance identified by its IP address and port.
+     * Implementors SHOULD override this method.
+     * The default implementation falls back to {@link #deregisterServiceInstance(String)},
+     * which may deregister ALL instances of the service.
+     */
+    default Uni<Void> deregisterServiceInstance(String serviceName, String ipAddress, int port) {
+        return deregisterServiceInstance(serviceName);
+    }
 
     record RegistrarOptions(String serviceName, String ipAddress, int defaultPort, List<String> tags,
             Map<String, String> metadata) {

--- a/core/src/main/java/io/smallrye/stork/utils/InMemoryAddressesBackend.java
+++ b/core/src/main/java/io/smallrye/stork/utils/InMemoryAddressesBackend.java
@@ -34,6 +34,13 @@ public class InMemoryAddressesBackend {
         }
     }
 
+    public static void remove(String serviceName, String address) {
+        List<String> addresses = backend.get(serviceName);
+        if (addresses != null) {
+            addresses.remove(address);
+        }
+    }
+
     public static void clearAll() {
         backend.clear();
     }

--- a/core/src/test/java/io/smallrye/stork/TestServiceRegistrar.java
+++ b/core/src/test/java/io/smallrye/stork/TestServiceRegistrar.java
@@ -19,13 +19,13 @@ public class TestServiceRegistrar implements ServiceRegistrar<TestMetadataKey> {
     }
 
     @Override
-    public Uni<Void> registerServiceInstance(String serviceName, Metadata<TestMetadataKey> metadata, String ipAddress,
-            int defaultPort) {
-        return null;
+    public Uni<Void> registerServiceInstance(String serviceName, String instanceName, Metadata<TestMetadataKey> metadata,
+            String ipAddress, int defaultPort) {
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Uni<Void> deregisterServiceInstance(String serviceName) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 }

--- a/docs/docs/service-registration/custom-service-registration.md
+++ b/docs/docs/service-registration/custom-service-registration.md
@@ -72,7 +72,21 @@ As you can see, the `AcmeConfiguration` class gives access to the configuration 
 
 #### Implement your own service deregistration mechanism
 
+The `registerServiceInstance` method receives an optional `instanceName` parameter that acts as an explicit identifier for the registered instance.
+When provided, it should be used as the registration ID so that the same instance can be precisely targeted during deregistration.
+If `instanceName` is `null` or empty, implementations should fall back to a deterministic ID derived from the service name, IP address, and port.
+
 Finally, you can implement your own service deregistration mechanism in `deregisterServiceInstance` method.
+
+!!! warning "Override the specific-instance deregistration methods"
+    The `ServiceRegistrar` interface provides several deregistration methods:
+
+    - `deregisterServiceInstance(String serviceName)` — deregisters **all** instances of a service.
+    - `deregisterServiceInstance(String serviceName, String instanceName)` — deregisters the instance registered under the given name.
+    - `deregisterServiceInstance(String serviceName, String ipAddress, int port)` — deregisters the instance identified by IP and port.
+
+    The default implementations of the second and third methods fall back to the first, which may deregister **all** instances.
+    **Custom registrar implementations should override at least one of the specific-instance methods** to provide precise, instance-level deregistration and avoid unintended side effects.
 
 
 ## Using your service registrar using the programmatic API

--- a/docs/docs/service-registration/overview.md
+++ b/docs/docs/service-registration/overview.md
@@ -40,6 +40,12 @@ This feature complements the registration mechanism.
 
 This operation is typically should be triggered when a service instance is shut down or no longer available, helping maintain a consistent and accurate service registry.
 To enable service deregistration, you can invoke the `deregisterServiceInstance` method on the `ServiceRegistrar` implementation programmatically.
+To target a specific instance, prefer one of these overloads:
+
+- `deregisterServiceInstance(serviceName, instanceName)` — deregisters the instance registered under the given name.
+- `deregisterServiceInstance(serviceName, ipAddress, port)` — deregisters the instance identified by IP and port.
+
+The single-argument overload `deregisterServiceInstance(serviceName)` deregisters **all** instances of the service.
 
 **Note**: When used in standalone mode, Stork does **not** automatically handle service instance registration or deregistration. 
 However, when using the quarkus-stork-registration extension within a Quarkus application, 

--- a/docs/snippets/examples/AcmeServiceRegistrar.java
+++ b/docs/snippets/examples/AcmeServiceRegistrar.java
@@ -16,7 +16,8 @@ public class AcmeServiceRegistrar implements ServiceRegistrar {
 
 
     @Override
-    public Uni<Void> registerServiceInstance(String serviceName, Metadata metadata, String ipAddress, int defaultPort) {
+    public Uni<Void> registerServiceInstance(String serviceName, String instanceName, Metadata metadata, String ipAddress, int defaultPort) {
+        //instanceName is an optional identifier for this specific instance; use it as the registration ID when provided
         //do whatever is needed for registering service instance
         return Uni.createFrom().voidItem();
     }

--- a/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrar.java
+++ b/service-registration/consul/src/main/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrar.java
@@ -1,9 +1,9 @@
 package io.smallrye.stork.serviceregistration.consul;
 
-import static io.smallrye.stork.impl.ConsulMetadataKey.META_CONSUL_SERVICE_ID;
-
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +18,8 @@ import io.vertx.core.net.JksOptions;
 import io.vertx.ext.consul.CheckOptions;
 import io.vertx.ext.consul.ConsulClient;
 import io.vertx.ext.consul.ConsulClientOptions;
+import io.vertx.ext.consul.Service;
+import io.vertx.ext.consul.ServiceList;
 import io.vertx.ext.consul.ServiceOptions;
 
 public class ConsulServiceRegistrar implements ServiceRegistrar<ConsulMetadataKey> {
@@ -57,20 +59,22 @@ public class ConsulServiceRegistrar implements ServiceRegistrar<ConsulMetadataKe
         checkRegistrarOptionsNotNull(options);
         checkAddressNotNull(options.ipAddress());
 
-        return registerInstance(options.serviceName(), options.ipAddress(), options.defaultPort(), options.serviceName(),
+        String consulId = buildConsulId(options.serviceName(), options.ipAddress(), options.defaultPort());
+        return registerInstance(options.serviceName(), options.ipAddress(), options.defaultPort(), consulId,
                 options.tags(), options.metadata());
 
     }
 
     @Override
-    public Uni<Void> registerServiceInstance(String serviceName, Metadata<ConsulMetadataKey> metadata, String ipAddress,
+    public Uni<Void> registerServiceInstance(String serviceName, String instanceName, Metadata<ConsulMetadataKey> metadata,
+            String ipAddress,
             int defaultPort) {
         checkAddressNotNull(ipAddress);
 
-        String consulId = metadata.getMetadata().isEmpty() ? serviceName
-                : metadata.getMetadata().get(ConsulMetadataKey.META_CONSUL_SERVICE_ID).toString();
-
-        return registerInstance(serviceName, ipAddress, defaultPort, consulId, List.of(), Map.of());
+        // Use the explicit ID when provided; otherwise generate a unique one.
+        String consulId = instanceName != null && !instanceName.isEmpty() ? instanceName
+                : buildConsulId(serviceName, ipAddress, defaultPort);
+        return registerInstance(serviceName, ipAddress, defaultPort, consulId, List.of(), Collections.emptyMap());
     }
 
     private Uni<Void> registerInstance(String serviceName, String ipAddress, int defaultPort, String consulId,
@@ -95,29 +99,81 @@ public class ConsulServiceRegistrar implements ServiceRegistrar<ConsulMetadataKe
                 serviceOptions)
                 .onComplete(result -> {
                     if (result.failed()) {
-                        log.error("Unable to register instances of service {}", serviceName,
+                        log.error("Unable to register instance {} of service {}", consulId, serviceName,
                                 result.cause());
                         em.fail(result.cause());
                     } else {
-                        log.info("Instances of service {} has been registered ", serviceName);
+                        log.info("Instance {} of service {} has been registered ", consulId, serviceName);
                         em.complete(result.result());
                     }
                 }));
     }
 
     @Override
-    public Uni<Void> deregisterServiceInstance(String serviceName) {
-        return Uni.createFrom().emitter(em -> client.deregisterService(serviceName)
+    public Uni<Void> deregisterServiceInstance(String serviceName, String instanceName) {
+        checkInstanceNameNotNull(instanceName);
+        return Uni.createFrom().emitter(em -> client.deregisterService(instanceName)
                 .onComplete(result -> {
                     if (result.failed()) {
-                        log.error("Unable to deregister instances of service {}", serviceName,
+                        log.error("Unable to deregister instance {} of service {}", instanceName, serviceName,
                                 result.cause());
                         em.fail(result.cause());
                     } else {
-                        log.info("Instances of service {} has been deregistered ", serviceName);
+                        log.info("Instance {} of service {} has been deregistered", instanceName, serviceName);
                         em.complete(result.result());
                     }
                 }));
+    }
+
+    /**
+     * Deregisters all instances of the given service from Consul by querying the catalog for their IDs
+     * and deregistering them in parallel. This avoids silent failures that would occur if the service ID
+     * were assumed to match the service name.
+     */
+    @Override
+    public Uni<Void> deregisterServiceInstance(String serviceName) {
+        return Uni.createFrom().<ServiceList> emitter(em -> client.catalogServiceNodes(serviceName).onComplete(result -> {
+            if (result.failed()) {
+                log.error("Unable to retrieve instances of service {} from Consul catalog", serviceName,
+                        result.cause());
+                em.fail(result.cause());
+            } else {
+                em.complete(result.result());
+            }
+        }))
+                .flatMap(serviceList -> {
+                    List<Service> services = serviceList.getList();
+                    if (services == null || services.isEmpty()) {
+                        log.info("No registered instances found for service {}", serviceName);
+                        return Uni.createFrom().voidItem();
+                    }
+                    List<Uni<Void>> deregistrations = services.stream()
+                            .map(service -> Uni.createFrom()
+                                    .<Void> emitter(em -> client.deregisterService(service.getId()).onComplete(result -> {
+                                        if (result.failed()) {
+                                            log.error("Unable to deregister instance {} of service {}",
+                                                    service.getId(), serviceName, result.cause());
+                                            em.fail(result.cause());
+                                        } else {
+                                            log.info("Instance {} of service {} has been deregistered",
+                                                    service.getId(), serviceName);
+                                            em.complete(null);
+                                        }
+                                    })))
+                            .collect(Collectors.toList());
+                    return Uni.combine().all().unis(deregistrations).discardItems();
+                });
+    }
+
+    @Override
+    public Uni<Void> deregisterServiceInstance(String serviceName, String ipAddress, int port) {
+        String consulId = buildConsulId(serviceName, ipAddress, port);
+        return deregisterServiceInstance(serviceName, consulId);
+    }
+
+    // '::' is used as separator; it does not appear in well-formed DNS service names, IP addresses, or port numbers.
+    private static String buildConsulId(String serviceName, String ipAddress, int port) {
+        return serviceName + "::" + ipAddress + "::" + port;
     }
 
     protected static Integer getPort(String name, String value) {

--- a/service-registration/consul/src/test/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrationTest.java
+++ b/service-registration/consul/src/test/java/io/smallrye/stork/serviceregistration/consul/ConsulServiceRegistrationTest.java
@@ -57,39 +57,6 @@ public class ConsulServiceRegistrationTest {
     }
 
     @Test
-    void shouldRegisterConsulIdDefaultingToServiceName() {
-        String serviceName = "my-service";
-        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
-                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
-                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
-        Stork stork = StorkTestUtils.getNewStorkInstance();
-
-        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
-
-        CountDownLatch registrationLatch = new CountDownLatch(1);
-        consulRegistrar.registerServiceInstance(serviceName, "10.96.96.231", 8406).subscribe()
-                .with(success -> registrationLatch.countDown(), failure -> fail(""));
-
-        await().atMost(Duration.ofSeconds(10))
-                .until(() -> registrationLatch.getCount() == 0L);
-
-        Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
-                emitter -> client.healthServiceNodes(serviceName, true)
-                        .onComplete(result -> {
-                            if (result.failed()) {
-                                emitter.fail(result.cause());
-                            } else {
-                                emitter.complete(result.result());
-                            }
-                        }));
-
-        UniAssertSubscriber<ServiceEntryList> subscriber = serviceEntryList
-                .subscribe().withSubscriber(UniAssertSubscriber.create());
-
-        assertThat(subscriber.awaitItem().getItem()).isNotNull();
-    }
-
-    @Test
     void shouldRegisterServiceInstancesInConsul() throws InterruptedException {
         String serviceName = "my-service";
         TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
@@ -205,8 +172,143 @@ public class ConsulServiceRegistrationTest {
         item.getList().stream().findFirst().ifPresent(service -> {
             assertThat(service.getChecks()).isNotEmpty();
             assertThat(service.getChecks().size()).isEqualTo(2);
-            assertThat(service.getChecks().stream().map(Check::getServiceId)).containsAnyOf("my-service");
+            assertThat(service.getChecks().stream().map(Check::getServiceId)).containsAnyOf("my-service::10.96.96.231::8406");
         });
+    }
+
+    @Test
+    void shouldRegisterMultipleInstancesWithUniqueDefaultConsulIds() throws InterruptedException {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.232", 8407).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> registrationLatch.getCount() == 0L);
+
+        Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
+                emitter -> client.healthServiceNodes(serviceName, true)
+                        .onComplete(result -> {
+                            if (result.failed()) {
+                                emitter.fail(result.cause());
+                            } else {
+                                emitter.complete(result.result());
+                            }
+                        }));
+
+        UniAssertSubscriber<ServiceEntryList> subscriber = serviceEntryList
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        ServiceEntryList item = subscriber.awaitItem().getItem();
+        assertThat(item).isNotNull();
+        assertThat(item.getList()).hasSize(2);
+        assertThat(item.getList()).extracting(e -> e.getService().getId())
+                .containsExactlyInAnyOrder("my-service::10.96.96.231::8406", "my-service::10.96.96.232::8407");
+        assertThat(item.getList()).extracting(e -> e.getService().getAddress())
+                .containsExactlyInAnyOrder("10.96.96.231", "10.96.96.232");
+    }
+
+    @Test
+    void shouldRegisterMultipleInstancesWithUniqueCustomConsulIds() throws InterruptedException {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+        consulRegistrar.registerServiceInstance(serviceName, "instance-one", Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+
+        consulRegistrar.registerServiceInstance(serviceName, "instance-two", Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.232", 8407).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> registrationLatch.getCount() == 0L);
+
+        Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
+                emitter -> client.healthServiceNodes(serviceName, true)
+                        .onComplete(result -> {
+                            if (result.failed()) {
+                                emitter.fail(result.cause());
+                            } else {
+                                emitter.complete(result.result());
+                            }
+                        }));
+
+        UniAssertSubscriber<ServiceEntryList> subscriber = serviceEntryList
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        ServiceEntryList item = subscriber.awaitItem().getItem();
+        assertThat(item).isNotNull();
+        assertThat(item.getList()).hasSize(2);
+        assertThat(item.getList()).extracting(e -> e.getService().getId())
+                .containsExactlyInAnyOrder("instance-one", "instance-two");
+        assertThat(item.getList()).extracting(e -> e.getService().getAddress())
+                .containsExactlyInAnyOrder("10.96.96.231", "10.96.96.232");
+    }
+
+    @Test
+    void shouldRegisterMultipleInstancesUsingOptionsWithUniqueConsulIds() throws InterruptedException {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+        ServiceRegistrar.RegistrarOptions options1 = new ServiceRegistrar.RegistrarOptions(serviceName, "10.96.96.231",
+                8406, List.of(), Map.of());
+        ServiceRegistrar.RegistrarOptions options2 = new ServiceRegistrar.RegistrarOptions(serviceName, "10.96.96.232",
+                8407, List.of(), Map.of());
+
+        consulRegistrar.registerServiceInstance(options1).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+
+        consulRegistrar.registerServiceInstance(options2).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> registrationLatch.getCount() == 0L);
+
+        Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
+                emitter -> client.healthServiceNodes(serviceName, true)
+                        .onComplete(result -> {
+                            if (result.failed()) {
+                                emitter.fail(result.cause());
+                            } else {
+                                emitter.complete(result.result());
+                            }
+                        }));
+
+        UniAssertSubscriber<ServiceEntryList> subscriber = serviceEntryList
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        ServiceEntryList item = subscriber.awaitItem().getItem();
+        assertThat(item).isNotNull();
+        assertThat(item.getList()).hasSize(2);
+        assertThat(item.getList()).extracting(e -> e.getService().getId())
+                .containsExactlyInAnyOrder("my-service::10.96.96.231::8406", "my-service::10.96.96.232::8407");
+        assertThat(item.getList()).extracting(e -> e.getService().getAddress())
+                .containsExactlyInAnyOrder("10.96.96.231", "10.96.96.232");
     }
 
     @Test
@@ -254,23 +356,30 @@ public class ConsulServiceRegistrationTest {
 
     @Test
     void shouldDeregisterServiceInstancesInConsul() throws InterruptedException {
-        //Given a service `my-service` registered in consul
         String serviceName = "my-service";
+        String ipAddress = "10.96.96.231";
+        int port = 8406;
         TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
                 null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
                 Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
         stork = StorkTestUtils.getNewStorkInstance();
-        List<String> tags = List.of("primary");
-        registerService(new ConsulServiceOptions(serviceName, 8406, tags, List.of("example.com")));
 
         ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
 
         CountDownLatch registrationLatch = new CountDownLatch(1);
-        consulRegistrar.deregisterServiceInstance(serviceName).subscribe()
-                .with(success -> registrationLatch.countDown(), failure -> fail(""));
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                ipAddress, port).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register instance"));
 
         await().atMost(Duration.ofSeconds(10))
                 .until(() -> registrationLatch.getCount() == 0L);
+
+        CountDownLatch deregistrationLatch = new CountDownLatch(1);
+        consulRegistrar.deregisterServiceInstance(serviceName, ipAddress, port).subscribe()
+                .with(success -> deregistrationLatch.countDown(), failure -> fail("Failed to deregister instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> deregistrationLatch.getCount() == 0L);
 
         Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
                 emitter -> client.healthServiceNodes(serviceName, true)
@@ -287,7 +396,199 @@ public class ConsulServiceRegistrationTest {
 
         ServiceEntryList item = subscriber.awaitItem().getItem();
         assertThat(item.getList()).isEmpty();
+    }
 
+    @Test
+    void shouldDeregisterServiceInstancesByNameInConsul() throws InterruptedException {
+        String serviceName = "my-service";
+        String ipAddress = "10.96.96.231";
+        int port = 8406;
+        String instanceName = "my-service-instance";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
+        stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(1);
+        consulRegistrar.registerServiceInstance(serviceName, instanceName, Metadata.of(ConsulMetadataKey.class),
+                ipAddress, port).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> registrationLatch.getCount() == 0L);
+
+        CountDownLatch deregistrationLatch = new CountDownLatch(1);
+        consulRegistrar.deregisterServiceInstance(serviceName, instanceName).subscribe()
+                .with(success -> deregistrationLatch.countDown(), failure -> fail("Failed to deregister instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> deregistrationLatch.getCount() == 0L);
+
+        Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
+                emitter -> client.healthServiceNodes(serviceName, true)
+                        .onComplete(result -> {
+                            if (result.failed()) {
+                                emitter.fail(result.cause());
+                            } else {
+                                emitter.complete(result.result());
+                            }
+                        }));
+
+        UniAssertSubscriber<ServiceEntryList> subscriber = serviceEntryList
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        ServiceEntryList item = subscriber.awaitItem().getItem();
+        assertThat(item.getList()).isEmpty();
+    }
+
+    @Test
+    void shouldDeregisterSpecificInstanceByAddressAndPort() throws InterruptedException {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
+        stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.232", 8407).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10)).until(() -> registrationLatch.getCount() == 0L);
+
+        CountDownLatch deregistrationLatch = new CountDownLatch(1);
+        consulRegistrar.deregisterServiceInstance(serviceName, "10.96.96.231", 8406).subscribe()
+                .with(success -> deregistrationLatch.countDown(), failure -> fail("Failed to deregister instance"));
+
+        await().atMost(Duration.ofSeconds(10)).until(() -> deregistrationLatch.getCount() == 0L);
+
+        Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
+                emitter -> client.healthServiceNodes(serviceName, true)
+                        .onComplete(result -> {
+                            if (result.failed()) {
+                                emitter.fail(result.cause());
+                            } else {
+                                emitter.complete(result.result());
+                            }
+                        }));
+
+        UniAssertSubscriber<ServiceEntryList> subscriber = serviceEntryList
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        ServiceEntryList item = subscriber.awaitItem().getItem();
+        assertThat(item.getList()).hasSize(1);
+        assertThat(item.getList().get(0).getService().getId()).isEqualTo("my-service::10.96.96.232::8407");
+        assertThat(item.getList().get(0).getService().getAddress()).isEqualTo("10.96.96.232");
+    }
+
+    @Test
+    void shouldDeregisterAllInstancesByServiceName() throws InterruptedException {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
+        stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.232", 8407).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10)).until(() -> registrationLatch.getCount() == 0L);
+
+        CountDownLatch deregistrationLatch = new CountDownLatch(1);
+        consulRegistrar.deregisterServiceInstance(serviceName).subscribe()
+                .with(success -> deregistrationLatch.countDown(), failure -> fail("Failed to deregister all instances"));
+
+        await().atMost(Duration.ofSeconds(10)).until(() -> deregistrationLatch.getCount() == 0L);
+
+        Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
+                emitter -> client.healthServiceNodes(serviceName, true)
+                        .onComplete(result -> {
+                            if (result.failed()) {
+                                emitter.fail(result.cause());
+                            } else {
+                                emitter.complete(result.result());
+                            }
+                        }));
+
+        UniAssertSubscriber<ServiceEntryList> subscriber = serviceEntryList
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        assertThat(subscriber.awaitItem().getItem().getList()).isEmpty();
+    }
+
+    @Test
+    void shouldDeregisterAllInstancesByInstanceName() throws InterruptedException {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
+                null, Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort), "refresh-period", "5"),
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
+        stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+        consulRegistrar.registerServiceInstance(serviceName, Metadata.of(ConsulMetadataKey.class),
+                "10.96.96.232", 8407).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10)).until(() -> registrationLatch.getCount() == 0L);
+
+        CountDownLatch deregistrationLatch = new CountDownLatch(1);
+        consulRegistrar.deregisterServiceInstance(serviceName, "my-service::10.96.96.231::8406").subscribe()
+                .with(success -> deregistrationLatch.countDown(), failure -> fail("Failed to deregister all instances"));
+
+        await().atMost(Duration.ofSeconds(10)).until(() -> deregistrationLatch.getCount() == 0L);
+
+        Uni<ServiceEntryList> serviceEntryList = Uni.createFrom().emitter(
+                emitter -> client.healthServiceNodes(serviceName, true)
+                        .onComplete(result -> {
+                            if (result.failed()) {
+                                emitter.fail(result.cause());
+                            } else {
+                                emitter.complete(result.result());
+                            }
+                        }));
+
+        UniAssertSubscriber<ServiceEntryList> subscriber = serviceEntryList
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        ServiceEntryList item = subscriber.awaitItem().getItem();
+        assertThat(item.getList()).hasSize(1);
+        assertThat(item.getList().get(0).getService().getId()).isEqualTo("my-service::10.96.96.232::8407");
+        assertThat(item.getList().get(0).getService().getAddress()).isEqualTo("10.96.96.232");
+    }
+
+    @Test
+    void shouldCompleteSuccessfullyWhenDeregisteringNonExistentService() {
+        String serviceName = "non-existent-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "consul",
+                null, null,
+                Map.of("consul-host", "localhost", "consul-port", String.valueOf(consulPort)));
+        stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<ConsulMetadataKey> consulRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        UniAssertSubscriber<Void> subscriber = consulRegistrar.deregisterServiceInstance(serviceName)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.awaitItem().assertCompleted();
     }
 
     public record ConsulServiceOptions(String serviceName, int port, List<String> tags, List<String> addresses) {

--- a/service-registration/eureka/src/main/java/io/smallrye/stork/serviceregistration/eureka/EurekaServiceRegistrar.java
+++ b/service-registration/eureka/src/main/java/io/smallrye/stork/serviceregistration/eureka/EurekaServiceRegistrar.java
@@ -1,5 +1,7 @@
 package io.smallrye.stork.serviceregistration.eureka;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -10,6 +12,7 @@ import io.smallrye.stork.api.Metadata;
 import io.smallrye.stork.api.ServiceRegistrar;
 import io.smallrye.stork.impl.EurekaMetadataKey;
 import io.smallrye.stork.spi.StorkInfrastructure;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.Vertx;
@@ -45,7 +48,8 @@ public class EurekaServiceRegistrar implements ServiceRegistrar<EurekaMetadataKe
 
         checkAddressNotNull(ipAddress);
 
-        String eurekaId = metadata.getMetadata().isEmpty() ? serviceName
+        String eurekaId = metadata.getMetadata().isEmpty()
+                ? buildEurekaId(serviceName, ipAddress, defaultPort)
                 : metadata.getMetadata().get(EurekaMetadataKey.META_EUREKA_SERVICE_ID).toString();
 
         return registerApplicationInstance(client, serviceName,
@@ -59,24 +63,66 @@ public class EurekaServiceRegistrar implements ServiceRegistrar<EurekaMetadataKe
         checkRegistrarOptionsNotNull(options);
         checkAddressNotNull(options.ipAddress());
 
+        String eurekaId = buildEurekaId(options.serviceName(), options.ipAddress(), options.defaultPort());
         return registerApplicationInstance(client, options.serviceName(),
-                options.serviceName(), options.ipAddress(), null,
+                eurekaId, options.ipAddress(), null,
                 options.defaultPort(), null, -1, "UP", options.metadata());
 
     }
 
+    /**
+     * Deregisters all instances of the given service from Eureka by querying the application endpoint for their IDs
+     * and deregistering them in parallel. This avoids silent failures that would occur if the service ID
+     * were assumed to match the service name.
+     */
     @Override
     public Uni<Void> deregisterServiceInstance(String serviceName) {
         return client.get(path + serviceName)
                 .putHeader("Accept", "application/json;charset=UTF-8")
-                .send().invoke(() -> log.info("Instance found for '{}'", serviceName))
+                .send()
                 .flatMap(item -> {
-                    JsonObject body = item.bodyAsJsonObject();
-                    JsonObject application = body.getJsonObject("application");
-                    JsonObject instance = application.getJsonArray("instance").getJsonObject(0);
-                    return deregisterApplicationInstance(application.getString("name"), instance.getString("instanceId"));
+                    if (item.statusCode() == 404) {
+                        log.info("No application found for '{}'", serviceName);
+                        return Uni.createFrom().voidItem();
+                    }
+                    if (item.statusCode() >= 400) {
+                        log.error("Eureka returned {} when querying instances for '{}'", item.statusCode(), serviceName);
+                        return Uni.createFrom().failure(new RuntimeException(
+                                "Eureka returned " + item.statusCode() + " when querying instances for '" + serviceName + "'"));
+                    }
+                    JsonObject application = item.bodyAsJsonObject().getJsonObject("application");
+                    String appName = application.getString("name");
+                    JsonArray instances = application.getJsonArray("instance");
+                    List<Uni<Void>> deregistrations = new ArrayList<>();
+                    for (int i = 0; i < instances.size(); i++) {
+                        String instanceId = instances.getJsonObject(i).getString("instanceId");
+                        deregistrations.add(deregisterApplicationInstance(appName, instanceId));
+                    }
+                    return Uni.combine().all().unis(deregistrations).discardItems();
                 });
+    }
 
+    @Override
+    public Uni<Void> registerServiceInstance(String serviceName, String instanceName, Metadata<EurekaMetadataKey> metadata,
+            String ipAddress, int defaultPort) {
+        checkAddressNotNull(ipAddress);
+        String eurekaId = instanceName != null && !instanceName.isEmpty()
+                ? instanceName
+                : buildEurekaId(serviceName, ipAddress, defaultPort);
+        return registerApplicationInstance(client, serviceName, eurekaId, ipAddress, null, defaultPort, null, -1, "UP",
+                metadata == null ? Metadata.empty().asMap() : metadata.asMap());
+    }
+
+    @Override
+    public Uni<Void> deregisterServiceInstance(String serviceName, String instanceName) {
+        checkInstanceNameNotNull(instanceName);
+        return deregisterApplicationInstance(serviceName, instanceName);
+    }
+
+    @Override
+    public Uni<Void> deregisterServiceInstance(String serviceName, String ipAddress, int port) {
+        String eurekaId = buildEurekaId(serviceName, ipAddress, port);
+        return deregisterApplicationInstance(serviceName, eurekaId);
     }
 
     private Uni<Void> deregisterApplicationInstance(String applicationId, String instanceId) {
@@ -86,8 +132,17 @@ public class EurekaServiceRegistrar implements ServiceRegistrar<EurekaMetadataKe
                 .onFailure()
                 .invoke(err -> log.error("Unable to deregister '{}' of '{}'. Error: {}", instanceId, applicationId,
                         err.getMessage()))
-                .onItem().invoke(resp -> log.info("'" + instanceId + "'" + " successfully deregistered")).replaceWithVoid();
-
+                .flatMap(resp -> {
+                    if (resp.statusCode() >= 400) {
+                        log.error("Eureka returned {} when deregistering '{}' of '{}'", resp.statusCode(), instanceId,
+                                applicationId);
+                        return Uni.createFrom().failure(new RuntimeException(
+                                "Eureka returned " + resp.statusCode() + " when deregistering '" + instanceId + "' of '"
+                                        + applicationId + "'"));
+                    }
+                    log.info("'{}' successfully deregistered", instanceId);
+                    return Uni.createFrom().voidItem();
+                });
     }
 
     private Uni<Void> registerApplicationInstance(WebClient client, String applicationId, String instanceId,
@@ -139,6 +194,11 @@ public class EurekaServiceRegistrar implements ServiceRegistrar<EurekaMetadataKe
 
         return response;
 
+    }
+
+    // '::' is used as separator; it does not appear in well-formed DNS service names, IP addresses, or port numbers.
+    private static String buildEurekaId(String serviceName, String ipAddress, int port) {
+        return serviceName + "::" + ipAddress + "::" + port;
     }
 
 }

--- a/service-registration/eureka/src/test/java/io/smallrye/stork/serviceregistration/eureka/EurekaRegistrarErrorHandlingTest.java
+++ b/service-registration/eureka/src/test/java/io/smallrye/stork/serviceregistration/eureka/EurekaRegistrarErrorHandlingTest.java
@@ -1,0 +1,96 @@
+package io.smallrye.stork.serviceregistration.eureka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.ServiceRegistrar;
+import io.smallrye.stork.impl.EurekaMetadataKey;
+import io.smallrye.stork.test.StorkTestUtils;
+import io.smallrye.stork.test.TestConfigProvider;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.http.HttpServer;
+
+public class EurekaRegistrarErrorHandlingTest {
+
+    private Vertx vertx;
+    private HttpServer mockServer;
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestConfigProvider.clear();
+        if (mockServer != null) {
+            mockServer.close().await().indefinitely();
+        }
+        vertx.close().await().indefinitely();
+    }
+
+    private void startMockServerAlwaysReturning(int statusCode) {
+        mockServer = vertx.createHttpServer()
+                .requestHandler(req -> req.response().setStatusCode(statusCode).endAndForget())
+                .listen(0).await().indefinitely();
+        port = mockServer.actualPort();
+    }
+
+    private void startMockServerWithGetOkDeleteFailing(int deleteStatusCode) {
+        String instancesResponse = "{\"application\":{\"name\":\"my-service\",\"instance\":[{\"instanceId\":\"my-service::localhost::8406\"}]}}";
+        mockServer = vertx.createHttpServer()
+                .requestHandler(req -> {
+                    if (req.method() == HttpMethod.GET) {
+                        req.response()
+                                .setStatusCode(200)
+                                .putHeader("content-type", "application/json")
+                                .endAndForget(instancesResponse);
+                    } else {
+                        req.response().setStatusCode(deleteStatusCode).endAndForget();
+                    }
+                })
+                .listen(0).await().indefinitely();
+        port = mockServer.actualPort();
+    }
+
+    private ServiceRegistrar<EurekaMetadataKey> registrarFor(String serviceName) {
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "eureka", null, null,
+                Map.of("eureka-host", "localhost", "eureka-port", String.valueOf(port)));
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+        return stork.getService(serviceName).getServiceRegistrar();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 400, 401, 403, 500, 503 })
+    void shouldFailWhenEurekaReturnsErrorOnListInstances(int statusCode) {
+        startMockServerAlwaysReturning(statusCode);
+        UniAssertSubscriber<Void> subscriber = registrarFor("my-service")
+                .deregisterServiceInstance("my-service")
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.awaitFailure();
+        assertThat(subscriber.getFailure().getMessage()).contains(String.valueOf(statusCode));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 400, 401, 403, 500, 503 })
+    void shouldFailWhenEurekaReturnsErrorOnDeleteInstance(int statusCode) {
+        startMockServerWithGetOkDeleteFailing(statusCode);
+        UniAssertSubscriber<Void> subscriber = registrarFor("my-service")
+                .deregisterServiceInstance("my-service", "localhost", 8406)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.awaitFailure();
+        assertThat(subscriber.getFailure().getMessage()).contains(String.valueOf(statusCode));
+    }
+}

--- a/service-registration/eureka/src/test/java/io/smallrye/stork/serviceregistration/eureka/EurekaRegistrationContextPathTest.java
+++ b/service-registration/eureka/src/test/java/io/smallrye/stork/serviceregistration/eureka/EurekaRegistrationContextPathTest.java
@@ -107,7 +107,7 @@ public class EurekaRegistrationContextPathTest {
         JsonObject application = jsonResponse.getJsonObject("application");
         JsonObject jsonServiceInstance = application.getJsonArray("instance").getJsonObject(0);
 
-        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
+        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service::localhost::8406");
         assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
         assertThat(jsonServiceInstance.getJsonObject("metadata").getString("protocol")).isEqualTo("https");
@@ -151,7 +151,7 @@ public class EurekaRegistrationContextPathTest {
         JsonObject application = jsonResponse.getJsonObject("application");
         JsonObject jsonServiceInstance = application.getJsonArray("instance").getJsonObject(0);
 
-        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
+        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service::localhost::8406");
         assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
         CountDownLatch deregistrationLatch = new CountDownLatch(1);

--- a/service-registration/eureka/src/test/java/io/smallrye/stork/serviceregistration/eureka/EurekaRegistrationTest.java
+++ b/service-registration/eureka/src/test/java/io/smallrye/stork/serviceregistration/eureka/EurekaRegistrationTest.java
@@ -148,7 +148,7 @@ public class EurekaRegistrationTest {
         JsonObject application = jsonResponse.getJsonObject("application");
         JsonObject jsonServiceInstance = application.getJsonArray("instance").getJsonObject(0);
 
-        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
+        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service::localhost::8406");
         assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
         assertThat(jsonServiceInstance.getString("vipAddress")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
@@ -191,7 +191,7 @@ public class EurekaRegistrationTest {
         JsonObject application = jsonResponse.getJsonObject("application");
         JsonObject jsonServiceInstance = application.getJsonArray("instance").getJsonObject(0);
 
-        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
+        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service::localhost::8406");
         assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
         assertThat(jsonServiceInstance.getString("vipAddress")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
@@ -252,12 +252,12 @@ public class EurekaRegistrationTest {
         JsonObject application = jsonResponse.getJsonObject("application");
         JsonObject jsonServiceInstance = application.getJsonArray("instance").getJsonObject(0);
 
-        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service");
+        assertThat(jsonServiceInstance.getString("instanceId")).isEqualTo("my-service::localhost::8406");
         assertThat(jsonServiceInstance.getString("ipAddr")).isEqualTo("localhost");
         assertThat(jsonServiceInstance.getString("vipAddress")).isEqualTo("my-service");
         assertThat(jsonServiceInstance.getJsonObject("port").getInteger("$")).isEqualTo(8406);
         CountDownLatch deregistrationLatch = new CountDownLatch(1);
-        eurekaServiceRegistrar.deregisterServiceInstance(serviceName)
+        eurekaServiceRegistrar.deregisterServiceInstance(serviceName, "localhost", 8406)
                 .subscribe()
                 .with(success -> deregistrationLatch.countDown(), failure -> fail("Failure: " + failure.getMessage()));
 
@@ -274,6 +274,192 @@ public class EurekaRegistrationTest {
         assertThat(httpResponse2).isNotNull();
         assertThat(httpResponse2.statusCode()).isEqualTo(404);
 
+    }
+
+    @Test
+    public void shouldRegisterMultipleInstancesWithUniqueEurekaIds(TestInfo info) {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "eureka", null, null,
+                Map.of("eureka-host", eureka.getHost(), "eureka-port", String.valueOf(port)));
+
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<EurekaMetadataKey> eurekaServiceRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+
+        eurekaServiceRegistrar.registerServiceInstance(serviceName, "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+
+        eurekaServiceRegistrar.registerServiceInstance(serviceName, "10.96.96.232", 8407).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> registrationLatch.getCount() == 0L);
+
+        Uni<HttpResponse<Buffer>> response = client.get("/eureka/apps/my-service")
+                .putHeader("Accept", "application/json;charset=UTF-8").send();
+
+        UniAssertSubscriber<HttpResponse<Buffer>> subscriber = response
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        HttpResponse<Buffer> httpResponse = subscriber.awaitItem().getItem();
+        assertThat(httpResponse).isNotNull();
+        assertThat(httpResponse.statusCode()).isEqualTo(200);
+
+        JsonObject jsonResponse = httpResponse.bodyAsJsonObject();
+        JsonObject application = jsonResponse.getJsonObject("application");
+        assertThat(application.getJsonArray("instance")).hasSize(2);
+    }
+
+    @Test
+    public void shouldDeregisterSpecificInstanceWhileKeepingOthers(TestInfo info) {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "eureka", null, null,
+                Map.of("eureka-host", eureka.getHost(), "eureka-port", String.valueOf(port)));
+
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<EurekaMetadataKey> eurekaServiceRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+
+        eurekaServiceRegistrar.registerServiceInstance(serviceName, "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+
+        eurekaServiceRegistrar.registerServiceInstance(serviceName, "10.96.96.232", 8407).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> registrationLatch.getCount() == 0L);
+
+        CountDownLatch deregistrationLatch = new CountDownLatch(1);
+        eurekaServiceRegistrar.deregisterServiceInstance(serviceName, "10.96.96.231", 8406)
+                .subscribe()
+                .with(success -> deregistrationLatch.countDown(), failure -> fail("Failure: " + failure.getMessage()));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> deregistrationLatch.getCount() == 0L);
+
+        Uni<HttpResponse<Buffer>> response = client.get("/eureka/apps/my-service")
+                .putHeader("Accept", "application/json;charset=UTF-8").send();
+
+        UniAssertSubscriber<HttpResponse<Buffer>> subscriber = response
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        HttpResponse<Buffer> httpResponse = subscriber.awaitItem().getItem();
+        assertThat(httpResponse).isNotNull();
+        assertThat(httpResponse.statusCode()).isEqualTo(200);
+
+        JsonObject jsonResponse = httpResponse.bodyAsJsonObject();
+        JsonObject application = jsonResponse.getJsonObject("application");
+        assertThat(application.getJsonArray("instance")).hasSize(1);
+
+        JsonObject remainingInstance = application.getJsonArray("instance").getJsonObject(0);
+        assertThat(remainingInstance.getString("instanceId")).isEqualTo("my-service::10.96.96.232::8407");
+    }
+
+    @Test
+    public void shouldRegisterWithCustomInstanceName(TestInfo info) {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "eureka", null, null,
+                Map.of("eureka-host", eureka.getHost(), "eureka-port", String.valueOf(port)));
+
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<EurekaMetadataKey> eurekaServiceRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(1);
+
+        eurekaServiceRegistrar.registerServiceInstance(serviceName, "my-custom-id", Metadata.of(EurekaMetadataKey.class),
+                "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> registrationLatch.getCount() == 0L);
+
+        Uni<HttpResponse<Buffer>> response = client.get("/eureka/apps/my-service")
+                .putHeader("Accept", "application/json;charset=UTF-8").send();
+
+        UniAssertSubscriber<HttpResponse<Buffer>> subscriber = response
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        HttpResponse<Buffer> httpResponse = subscriber.awaitItem().getItem();
+        assertThat(httpResponse).isNotNull();
+        assertThat(httpResponse.statusCode()).isEqualTo(200);
+
+        JsonObject jsonResponse = httpResponse.bodyAsJsonObject();
+        JsonObject application = jsonResponse.getJsonObject("application");
+        JsonObject instance = application.getJsonArray("instance").getJsonObject(0);
+        assertThat(instance.getString("instanceId")).isEqualTo("my-custom-id");
+        assertThat(instance.getString("ipAddr")).isEqualTo("10.96.96.231");
+    }
+
+    @Test
+    public void shouldDeregisterByInstanceName(TestInfo info) {
+        String serviceName = "my-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "eureka", null, null,
+                Map.of("eureka-host", eureka.getHost(), "eureka-port", String.valueOf(port)));
+
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<EurekaMetadataKey> eurekaServiceRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        CountDownLatch registrationLatch = new CountDownLatch(2);
+
+        eurekaServiceRegistrar.registerServiceInstance(serviceName, "instance-one", Metadata.of(EurekaMetadataKey.class),
+                "10.96.96.231", 8406).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register first instance"));
+
+        eurekaServiceRegistrar.registerServiceInstance(serviceName, "instance-two", Metadata.of(EurekaMetadataKey.class),
+                "10.96.96.232", 8407).subscribe()
+                .with(success -> registrationLatch.countDown(), failure -> fail("Failed to register second instance"));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> registrationLatch.getCount() == 0L);
+
+        CountDownLatch deregistrationLatch = new CountDownLatch(1);
+        eurekaServiceRegistrar.deregisterServiceInstance(serviceName, "instance-one")
+                .subscribe()
+                .with(success -> deregistrationLatch.countDown(), failure -> fail("Failure: " + failure.getMessage()));
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> deregistrationLatch.getCount() == 0L);
+
+        Uni<HttpResponse<Buffer>> response = client.get("/eureka/apps/my-service")
+                .putHeader("Accept", "application/json;charset=UTF-8").send();
+
+        UniAssertSubscriber<HttpResponse<Buffer>> subscriber = response
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        HttpResponse<Buffer> httpResponse = subscriber.awaitItem().getItem();
+        assertThat(httpResponse).isNotNull();
+        assertThat(httpResponse.statusCode()).isEqualTo(200);
+
+        JsonObject jsonResponse = httpResponse.bodyAsJsonObject();
+        JsonObject application = jsonResponse.getJsonObject("application");
+        assertThat(application.getJsonArray("instance")).hasSize(1);
+
+        JsonObject remainingInstance = application.getJsonArray("instance").getJsonObject(0);
+        assertThat(remainingInstance.getString("instanceId")).isEqualTo("instance-two");
+    }
+
+    @Test
+    public void shouldCompleteSuccessfullyWhenDeregisteringNonExistentService(TestInfo info) {
+        String serviceName = "non-existent-service";
+        TestConfigProvider.addServiceConfig(serviceName, null, null, "eureka", null, null,
+                Map.of("eureka-host", eureka.getHost(), "eureka-port", String.valueOf(port)));
+
+        Stork stork = StorkTestUtils.getNewStorkInstance();
+
+        ServiceRegistrar<EurekaMetadataKey> eurekaServiceRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        // Deregistering a service that was never registered should complete without error,
+        // not throw a NullPointerException when parsing the 404 response body.
+        UniAssertSubscriber<Void> subscriber = eurekaServiceRegistrar.deregisterServiceInstance(serviceName)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.awaitItem().assertCompleted();
     }
 
 }

--- a/service-registration/static-list/src/main/java/io/smallrye/stork/serviceregistration/staticlist/StaticListServiceRegistrar.java
+++ b/service-registration/static-list/src/main/java/io/smallrye/stork/serviceregistration/staticlist/StaticListServiceRegistrar.java
@@ -21,6 +21,12 @@ public class StaticListServiceRegistrar implements ServiceRegistrar<Metadata.Def
     }
 
     @Override
+    public Uni<Void> registerServiceInstance(String serviceName, String instanceName,
+            Metadata<Metadata.DefaultMetadataKey> metadata, String ipAddress, int defaultPort) {
+        return registerServiceInstance(serviceName, metadata, ipAddress, defaultPort);
+    }
+
+    @Override
     public Uni<Void> registerServiceInstance(String serviceName, Metadata<Metadata.DefaultMetadataKey> metadata,
             String ipAddress,
             int defaultPort) {
@@ -36,6 +42,16 @@ public class StaticListServiceRegistrar implements ServiceRegistrar<Metadata.Def
     @Override
     public Uni<Void> deregisterServiceInstance(String serviceName) {
         InMemoryAddressesBackend.clear(serviceName);
+        return Uni.createFrom().voidItem();
+    }
+
+    @Override
+    public Uni<Void> deregisterServiceInstance(String serviceName, String ipAddress, int port) {
+        HostAndPort hostAndPort = StorkAddressUtils.parseToHostAndPort(ipAddress, port,
+                "service '" + serviceName + "'");
+        String address = StorkAddressUtils.parseToString(hostAndPort);
+        InMemoryAddressesBackend.remove(serviceName, address);
+        log.info("Address {} has been deregistered for service {}", address, serviceName);
         return Uni.createFrom().voidItem();
     }
 

--- a/service-registration/static-list/src/test/java/io/smallrye/stork/serviceregistration/staticlist/StaticServiceRegistrationTest.java
+++ b/service-registration/static-list/src/test/java/io/smallrye/stork/serviceregistration/staticlist/StaticServiceRegistrationTest.java
@@ -93,6 +93,49 @@ public class StaticServiceRegistrationTest {
     }
 
     @Test
+    void shouldDeregisterSingleInstanceWithoutAffectingOthers() {
+        TestConfigProvider.addServiceConfig("first-service", null, null, "static",
+                null, null, null);
+
+        stork = StorkTestUtils.getNewStorkInstance();
+
+        String serviceName = "first-service";
+
+        ServiceRegistrar<Metadata.DefaultMetadataKey> staticRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        staticRegistrar.registerServiceInstance(serviceName, "localhost", 8080);
+        staticRegistrar.registerServiceInstance(serviceName, "localhost", 8081);
+        staticRegistrar.registerServiceInstance(serviceName, "remotehost", 9090);
+
+        assertThat(InMemoryAddressesBackend.getAddresses(serviceName)).hasSize(3);
+
+        staticRegistrar.deregisterServiceInstance(serviceName, "localhost", 8081);
+
+        List<String> addresses = InMemoryAddressesBackend.getAddresses(serviceName);
+        assertThat(addresses).hasSize(2);
+        assertThat(addresses).containsExactlyInAnyOrder("localhost:8080", "remotehost:9090");
+    }
+
+    @Test
+    void shouldRegisterWithCustomInstanceNameIgnoringName() {
+        TestConfigProvider.addServiceConfig("first-service", null, null, "static",
+                null, null, null);
+
+        stork = StorkTestUtils.getNewStorkInstance();
+
+        String serviceName = "first-service";
+
+        ServiceRegistrar<Metadata.DefaultMetadataKey> staticRegistrar = stork.getService(serviceName).getServiceRegistrar();
+
+        staticRegistrar.registerServiceInstance(serviceName, "my-custom-id", Metadata.of(Metadata.DefaultMetadataKey.class),
+                "localhost", 8080);
+
+        List<String> addresses = InMemoryAddressesBackend.getAddresses(serviceName);
+        assertThat(addresses).hasSize(1);
+        assertThat(addresses).contains("localhost:8080");
+    }
+
+    @Test
     void shouldFailIfAddresseNull() {
         TestConfigProvider.addServiceConfig("first-service", null, null, "static",
                 null, null, null);

--- a/test-utils/revapi.json
+++ b/test-utils/revapi.json
@@ -41,6 +41,20 @@
         "new": "class io.smallrye.stork.test.TestServiceRegistrarProvider",
         "annotation": "@io.smallrye.stork.api.config.ServiceRegistrarAttributes({@io.smallrye.stork.api.config.ServiceRegistrarAttribute(name = \"one\", description = \"no description\"), @io.smallrye.stork.api.config.ServiceRegistrarAttribute(name = \"two\", description = \"no description\")})",
         "justification": "New registrar API"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.stork.test.TestServiceRegistrarProvider.Registration::<init>(java.lang.String, io.smallrye.stork.test.TestSrRegistrarConfiguration, io.smallrye.stork.api.Metadata<io.smallrye.stork.test.TestServiceRegistrarProvider.TestMetadata>, java.lang.String, java.lang.String, int)",
+        "new": "method void io.smallrye.stork.test.TestServiceRegistrarProvider.Registration::<init>(java.lang.String, io.smallrye.stork.test.TestSrRegistrarConfiguration, io.smallrye.stork.api.Metadata<io.smallrye.stork.test.TestServiceRegistrarProvider.TestMetadata>, java.lang.String, java.lang.String, java.lang.String, int)",
+        "justification": "Added instanceName parameter to Registration constructor and TestServiceRegistrar to support the new abstract method in ServiceRegistrar. Test-only class; no production callers affected."
+      },
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method io.smallrye.mutiny.Uni<java.lang.Void> io.smallrye.stork.test.TestServiceRegistrarProvider.TestServiceRegistrar::registerServiceInstance(java.lang.String, io.smallrye.stork.api.Metadata<io.smallrye.stork.test.TestServiceRegistrarProvider.TestMetadata>, java.lang.String, int)",
+        "new": "method io.smallrye.mutiny.Uni<java.lang.Void> io.smallrye.stork.test.TestServiceRegistrarProvider.TestServiceRegistrar::registerServiceInstance(java.lang.String, java.lang.String, io.smallrye.stork.api.Metadata<io.smallrye.stork.test.TestServiceRegistrarProvider.TestMetadata>, java.lang.String, int)",
+        "justification": "Added instanceName parameter to Registration constructor and TestServiceRegistrar to support the new abstract method in ServiceRegistrar. Test-only class; no production callers affected."
       }
     ]
   }

--- a/test-utils/src/main/java/io/smallrye/stork/test/TestServiceRegistrarProvider.java
+++ b/test-utils/src/main/java/io/smallrye/stork/test/TestServiceRegistrarProvider.java
@@ -42,14 +42,16 @@ public class TestServiceRegistrarProvider
         public final String ipAddress;
         public final int port;
         public final String serviceName;
+        public final String instanceName;
 
         public Registration(String serviceRegistrarName, TestSrRegistrarConfiguration config, Metadata<TestMetadata> metadata,
-                String serviceName, String ipAddress, int port) {
+                String serviceName, String instanceName, String ipAddress, int port) {
             this.serviceRegistrarName = serviceRegistrarName;
             this.config = config;
             this.metadata = metadata;
             this.ipAddress = ipAddress;
             this.serviceName = serviceName;
+            this.instanceName = instanceName;
             this.port = port;
         }
     }
@@ -65,9 +67,10 @@ public class TestServiceRegistrarProvider
         }
 
         @Override
-        public Uni<Void> registerServiceInstance(String serviceName, Metadata<TestMetadata> metadata, String ipAddress,
-                int defaultPort) {
-            registrations.add(new Registration(serviceRegistrarName, config, metadata, serviceName, ipAddress, defaultPort));
+        public Uni<Void> registerServiceInstance(String serviceName, String instanceName, Metadata<TestMetadata> metadata,
+                String ipAddress, int defaultPort) {
+            registrations.add(new Registration(serviceRegistrarName, config, metadata, serviceName, instanceName, ipAddress,
+                    defaultPort));
             return Uni.createFrom().voidItem();
         }
 


### PR DESCRIPTION
Add instanceName support to ServiceRegistrar

Introduce registerServiceInstance(serviceName, instanceName, metadata, ip, port) as a new abstract method on ServiceRegistrar so callers can supply an explicit instance ID instead of the auto-generated serviceName::ip::port format. The existing 4-arg signature becomes a default that delegates to the new 5-arg with null, preserving backwards compatibility.
Also adds deregisterServiceInstance(serviceName, instanceName) to allow deregistration by an explicit ID, with concrete implementations in Consul and Eureka.

Fixes #1241