### PR TITLE
fix: bump to Mutiny Vert.x bindings 3.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <version.mutiny>3.2.0</version.mutiny>
         <version.smallrye-config>3.17.2</version.smallrye-config>
 
-        <version.vertx-mutiny-bindings>3.21.6</version.vertx-mutiny-bindings>
+        <version.vertx-mutiny-bindings>3.22.2</version.vertx-mutiny-bindings>
         <vertx.version>4.5.27</vertx.version>
 
         <!-- override the testcontainers version with the newest one -->

--- a/service-registration/eureka/src/main/java/module-info.java
+++ b/service-registration/eureka/src/main/java/module-info.java
@@ -38,8 +38,6 @@ module io.smallrye.stork.serviceregistration.eureka {
     requires com.fasterxml.jackson.core;
     requires io.smallrye.mutiny.vertx.core;
     requires io.smallrye.mutiny.vertx.runtime;
-    requires io.smallrye.mutiny.vertx.codegen.generatorv4;
-    requires io.vertx.codegen;
     requires io.smallrye.mutiny.vertx.auth.common;
     requires io.smallrye.mutiny.vertx.web.common;
     requires io.smallrye.mutiny.vertx.uri.template;


### PR DESCRIPTION
This fixes a Java module descriptor as the Mutiny bindings now have an optional runtime dependency on the Vert.x code generator code annotations.

Supersedes #1228