### PR TITLE
Update Mockito to 5.18.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,11 +50,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <kubernetes-client.version>7.8.0</kubernetes-client.version>
         <!-- we cannot update to 2.x as jboss-logging does not support SLF4J 2 for now -->
         <version.slf4j>2.0.18</version.slf4j>
-        <version.mockito>5.2.0</version.mockito>
+        <version.mockito>5.18.0</version.mockito>
         <version.jackson>2.22.2</version.jackson>
         <version.weld>6.0.4.Final</version.weld>
         <version.spring-boot>4.1.1</version.spring-boot>
@@ -175,12 +175,6 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>${version.mockito}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
                 <version>${version.mockito}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
- Fixes #1346 

Bumping `surefire` to `3.6.0` via `smallrye-parent`  breaks the core build with `MockitoInitializationException: Could not initialize inline Byte Buddy mock maker`. See https://github.com/smallrye/smallrye-parent/pull/681

I wasn't able to reproduce it locally, but it seems to be a classpath ordering issue due to https://github.com/apache/maven-surefire/pull/3333

This should be caused by a `byte-buddy` version mismatch, both included in `asserj-core` and `mockito`.
